### PR TITLE
#24 Update Jackson dependency to fix vulnerabilities that are found in the used version.

### DIFF
--- a/languages/merlinBuild/models/merlinBuild.behavior.mps
+++ b/languages/merlinBuild/models/merlinBuild.behavior.mps
@@ -2473,7 +2473,7 @@
       <node concept="3clFbS" id="3r0zJz5WybF" role="3clF47">
         <node concept="3cpWs6" id="3r0zJz5WybG" role="3cqZAp">
           <node concept="Xl_RD" id="3r0zJz5WybH" role="3cqZAk">
-            <property role="Xl_RC" value="2.21.4" />
+            <property role="Xl_RC" value="2.21.5" />
           </node>
         </node>
       </node>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<junitAssert.version>4.13.2</junitAssert.version>
 		<jetty.version>12.0.33</jetty.version>
 		<jackson-annotations.version>2.21</jackson-annotations.version>
-		<jackson-databind.version>2.21.4</jackson-databind.version>
+		<jackson-databind.version>2.21.5</jackson-databind.version>
 		<slf4jSimple.version>2.0.17</slf4jSimple.version>
 		<jakartaXmlWsApi.version>4.0.3</jakartaXmlWsApi.version>
 		<jakartaXmlSoapApi.version>3.0.2</jakartaXmlSoapApi.version>


### PR DESCRIPTION
The dependency op jackson, for ALEF and the generated services, has been updated to a newer version due to a known vulnerability.