### PR TITLE
#47: Fix model-checks on entrypoint and remove irrelevant check in code-generator

### DIFF
--- a/languages/merlinService/generator/templates/merlinService.generator.templates@generator.mps
+++ b/languages/merlinService/generator/templates/merlinService.generator.templates@generator.mps
@@ -21459,6 +21459,7 @@
             <node concept="3cpWs8" id="7Q62q1GC1ly" role="3cqZAp">
               <node concept="3cpWsn" id="7Q62q1GC1lz" role="3cpWs9">
                 <property role="TrG5h" value="onderwerp" />
+                <property role="3TUv4t" value="true" />
                 <node concept="3uibUv" id="533$emjj8JC" role="1tU5fm">
                   <ref role="3uigEE" to="jyki:~MObject" resolve="MObject" />
                 </node>
@@ -21948,55 +21949,6 @@
               </node>
               <node concept="37vLTw" id="4HsIWKbOnwu" role="1DdaDG">
                 <ref role="3cqZAo" node="2anHkv4M0bv" resolve="loggers" />
-              </node>
-            </node>
-          </node>
-          <node concept="1ps_y7" id="6RoaLN_r5dm" role="lGtFl">
-            <node concept="1ps_xZ" id="6RoaLN_r5dn" role="1ps_xO">
-              <property role="TrG5h" value="onderwerp" />
-              <node concept="2jfdEK" id="6RoaLN_r5do" role="1ps_xN">
-                <node concept="3clFbS" id="6RoaLN_r5dp" role="2VODD2">
-                  <node concept="3cpWs8" id="6RoaLN_dvNl" role="3cqZAp">
-                    <node concept="3cpWsn" id="6RoaLN_dvNm" role="3cpWs9">
-                      <property role="TrG5h" value="t" />
-                      <node concept="3Tqbb2" id="6RoaLN_dvNn" role="1tU5fm">
-                        <ref role="ehGHo" to="3ic2:$infi2rtPg" resolve="ObjectType" />
-                      </node>
-                      <node concept="2OqwBi" id="rblCq3fF$X" role="33vP2m">
-                        <node concept="30H73N" id="rblCq3fBcA" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="rblCq3fMnz" role="2OqNvi">
-                          <ref role="37wK5l" to="txb8:76ic8nBJn84" resolve="mapsToObjectType" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="6RoaLN_YPCK" role="3cqZAp">
-                    <node concept="3clFbS" id="6RoaLN_YPCM" role="3clFbx">
-                      <node concept="3clFbF" id="6RoaLN_WFIe" role="3cqZAp">
-                        <node concept="2OqwBi" id="6RoaLN_WFIf" role="3clFbG">
-                          <node concept="1iwH7S" id="6RoaLN_WFIg" role="2Oq$k0" />
-                          <node concept="2k5nB$" id="6RoaLN_WFIh" role="2OqNvi">
-                            <node concept="Xl_RD" id="6RoaLN_WFIi" role="2k5Stb">
-                              <property role="Xl_RC" value="Objecttype kan niet bepaald worden a.d.h.v. invoer of flow" />
-                            </node>
-                            <node concept="30H73N" id="6RoaLN_WFIj" role="2k6f33" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbC" id="6RoaLN_YZ_I" role="3clFbw">
-                      <node concept="10Nm6u" id="6RoaLN_Z5X7" role="3uHU7w" />
-                      <node concept="37vLTw" id="6RoaLN_YV65" role="3uHU7B">
-                        <ref role="3cqZAo" node="6RoaLN_dvNm" resolve="t" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs6" id="6RoaLN_dwju" role="3cqZAp">
-                    <node concept="37vLTw" id="6RoaLN_dwrV" role="3cqZAk">
-                      <ref role="3cqZAo" node="6RoaLN_dvNm" resolve="t" />
-                    </node>
-                  </node>
-                </node>
               </node>
             </node>
           </node>

--- a/languages/servicespraak/models/typesystem.mps
+++ b/languages/servicespraak/models/typesystem.mps
@@ -75,7 +75,6 @@
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
-        <property id="2523873803623706117" name="isMultiline" index="hSjvv" />
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
@@ -6908,6 +6907,23 @@
   <node concept="18kY7G" id="2a2AOY7jNuR">
     <property role="TrG5h" value="check_Entrypoint" />
     <node concept="3clFbS" id="2a2AOY7jNuS" role="18ibNy">
+      <node concept="3cpWs8" id="3KMP7S1gJ6u" role="3cqZAp">
+        <node concept="3cpWsn" id="3KMP7S1gJ6s" role="3cpWs9">
+          <property role="TrG5h" value="inputs" />
+          <property role="3TUv4t" value="true" />
+          <node concept="2I9FWS" id="3KMP7S1gJ6t" role="1tU5fm">
+            <ref role="2I9WkF" to="ku5w:1ikyrmjHd1n" resolve="BerichtVeld" />
+          </node>
+          <node concept="2OqwBi" id="5$8nGEkWCuJ" role="33vP2m">
+            <node concept="1YBJjd" id="5$8nGEkWB_g" role="2Oq$k0">
+              <ref role="1YBMHb" node="2a2AOY7jNuU" resolve="entrypoint" />
+            </node>
+            <node concept="3Tsc0h" id="5$8nGEkWFdR" role="2OqNvi">
+              <ref role="3TtcxE" to="ku5w:2a2AOY3pVMc" resolve="invoer" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3clFbJ" id="7BFdRvtdxHB" role="3cqZAp">
         <node concept="3clFbS" id="7BFdRvtdxHD" role="3clFbx">
           <node concept="3cpWs8" id="7GYmR1bTbdM" role="3cqZAp">
@@ -6947,13 +6963,8 @@
                 </node>
               </node>
               <node concept="2OqwBi" id="5kgm8JvpUw" role="33vP2m">
-                <node concept="2OqwBi" id="5kgm8JvpUx" role="2Oq$k0">
-                  <node concept="1YBJjd" id="5kgm8JvpUy" role="2Oq$k0">
-                    <ref role="1YBMHb" node="2a2AOY7jNuU" resolve="entrypoint" />
-                  </node>
-                  <node concept="3Tsc0h" id="5kgm8JvpUz" role="2OqNvi">
-                    <ref role="3TtcxE" to="ku5w:2a2AOY3pVMc" resolve="invoer" />
-                  </node>
+                <node concept="37vLTw" id="3KMP7S1hqLf" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3KMP7S1gJ6s" resolve="inputs" />
                 </node>
                 <node concept="v3k3i" id="5kgm8JvpU$" role="2OqNvi">
                   <node concept="chp4Y" id="5kgm8JvpU_" role="v3oSu">
@@ -7131,18 +7142,176 @@
         </node>
         <node concept="9aQIb" id="7BFdRvvU1Et" role="9aQIa">
           <node concept="3clFbS" id="7BFdRvvU1Eu" role="9aQI4">
-            <node concept="3clFbF" id="5$8nGEkWB5N" role="3cqZAp">
-              <node concept="2OqwBi" id="5$8nGEkWB5H" role="3clFbG">
-                <node concept="2WthIp" id="5$8nGEkWB5K" role="2Oq$k0" />
-                <node concept="2XshWL" id="5$8nGEkWB5M" role="2OqNvi">
-                  <ref role="2WH_rO" node="5$8nGEkWk$f" resolve="checkGelijkeObjecttypes" />
-                  <node concept="2OqwBi" id="5$8nGEkWCuJ" role="2XxRq1">
-                    <node concept="1YBJjd" id="5$8nGEkWB_g" role="2Oq$k0">
-                      <ref role="1YBMHb" node="2a2AOY7jNuU" resolve="entrypoint" />
+            <node concept="3cpWs8" id="3KMP7S1gJ5s" role="3cqZAp">
+              <node concept="3cpWsn" id="3KMP7S1gJ5t" role="3cpWs9">
+                <property role="TrG5h" value="objectTypes" />
+                <property role="3TUv4t" value="true" />
+                <node concept="2I9FWS" id="3KMP7S1sVGe" role="1tU5fm">
+                  <ref role="2I9WkF" to="3ic2:$infi2rtPg" resolve="ObjectType" />
+                </node>
+                <node concept="2OqwBi" id="3KMP7S1sYs1" role="33vP2m">
+                  <node concept="2OqwBi" id="3KMP7S1gJ5w" role="2Oq$k0">
+                    <node concept="2OqwBi" id="3KMP7S1gJ5x" role="2Oq$k0">
+                      <node concept="2OqwBi" id="3KMP7S1gJ5y" role="2Oq$k0">
+                        <node concept="37vLTw" id="3KMP7S1gJ6w" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3KMP7S1gJ6s" resolve="inputs" />
+                        </node>
+                        <node concept="3$u5V9" id="3KMP7S1gJ5$" role="2OqNvi">
+                          <node concept="1bVj0M" id="3KMP7S1gJ5_" role="23t8la">
+                            <node concept="3clFbS" id="3KMP7S1gJ5A" role="1bW5cS">
+                              <node concept="3clFbF" id="3KMP7S1gJ5B" role="3cqZAp">
+                                <node concept="2OqwBi" id="3KMP7S1gJ5C" role="3clFbG">
+                                  <node concept="2WthIp" id="3KMP7S1gJ6y" role="2Oq$k0" />
+                                  <node concept="2XshWL" id="3KMP7S1gJ5E" role="2OqNvi">
+                                    <ref role="2WH_rO" node="7BFdRvvUHFd" resolve="objectType" />
+                                    <node concept="37vLTw" id="3KMP7S1gJ5F" role="2XxRq1">
+                                      <ref role="3cqZAo" node="3KMP7S1gJ5G" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gl6BB" id="3KMP7S1gJ5G" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="3KMP7S1gJ5H" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1KnU$U" id="3KMP7S1gJ5I" role="2OqNvi" />
                     </node>
-                    <node concept="3Tsc0h" id="5$8nGEkWFdR" role="2OqNvi">
-                      <ref role="3TtcxE" to="ku5w:2a2AOY3pVMc" resolve="invoer" />
+                    <node concept="1VAtEI" id="3KMP7S1gJ5J" role="2OqNvi" />
+                  </node>
+                  <node concept="ANE8D" id="3KMP7S1t0Jg" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="3KMP7S1h5jH" role="3cqZAp">
+              <node concept="3cpWsn" id="3KMP7S1h5jI" role="3cpWs9">
+                <property role="TrG5h" value="n" />
+                <property role="3TUv4t" value="true" />
+                <node concept="10Oyi0" id="3KMP7S1h5bF" role="1tU5fm" />
+                <node concept="2OqwBi" id="3KMP7S1h5jJ" role="33vP2m">
+                  <node concept="37vLTw" id="3KMP7S1h5jK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3KMP7S1gJ5t" resolve="objectTypes" />
+                  </node>
+                  <node concept="34oBXx" id="3KMP7S1h5jL" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3KMP7S1gR0Q" role="3cqZAp">
+              <node concept="3clFbS" id="3KMP7S1gR0S" role="3clFbx">
+                <node concept="2MkqsV" id="4UYgXtXstHH" role="3cqZAp">
+                  <node concept="Xl_RD" id="4UYgXtXstHI" role="2MkJ7o">
+                    <property role="Xl_RC" value="Het service-entrypoint heeft geen invoer (of een start-flow) met een onderwerp" />
+                  </node>
+                  <node concept="1YBJjd" id="4UYgXtXstHJ" role="1urrMF">
+                    <ref role="1YBMHb" node="2a2AOY7jNuU" resolve="entrypoint" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3eOVzh" id="3KMP7S1gS5p" role="3clFbw">
+                <node concept="37vLTw" id="3KMP7S1h5jM" role="3uHU7B">
+                  <ref role="3cqZAo" node="3KMP7S1h5jI" resolve="n" />
+                </node>
+                <node concept="3cmrfG" id="3KMP7S1gRVu" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+              <node concept="3eNFk2" id="3KMP7S1h4d8" role="3eNLev">
+                <node concept="3clFbS" id="3KMP7S1h4da" role="3eOfB_">
+                  <node concept="2Gpval" id="3KMP7S1gJ5M" role="3cqZAp">
+                    <node concept="2GrKxI" id="3KMP7S1gJ5N" role="2Gsz3X">
+                      <property role="TrG5h" value="afwijkendVeld" />
                     </node>
+                    <node concept="3clFbS" id="3KMP7S1gJ5O" role="2LFqv$">
+                      <node concept="2MkqsV" id="3KMP7S1gJ5P" role="3cqZAp">
+                        <node concept="3cpWs3" id="3KMP7S1gJ5Q" role="2MkJ7o">
+                          <node concept="Xl_RD" id="3KMP7S1gJ5R" role="3uHU7w">
+                            <property role="Xl_RC" value="." />
+                          </node>
+                          <node concept="3cpWs3" id="3KMP7S1gJ5S" role="3uHU7B">
+                            <node concept="Xl_RD" id="3KMP7S1gJ5T" role="3uHU7B">
+                              <property role="Xl_RC" value="De verschillende velden moeten bij één enkel objecttype horen. Nu " />
+                            </node>
+                            <node concept="2YIFZM" id="3KMP7S1gJ5U" role="3uHU7w">
+                              <ref role="37wK5l" to="5iz4:2n2csM8gcRA" resolve="joinWithCommaEn" />
+                              <ref role="1Pybhc" to="5iz4:5vjARXKnVvl" resolve="StringUtil" />
+                              <node concept="2OqwBi" id="3KMP7S1gJ5V" role="37wK5m">
+                                <node concept="37vLTw" id="3KMP7S1gJ5W" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3KMP7S1gJ5t" resolve="objectTypes" />
+                                </node>
+                                <node concept="3$u5V9" id="3KMP7S1gJ5X" role="2OqNvi">
+                                  <node concept="1bVj0M" id="3KMP7S1gJ5Y" role="23t8la">
+                                    <node concept="3clFbS" id="3KMP7S1gJ5Z" role="1bW5cS">
+                                      <node concept="3clFbF" id="3KMP7S1gJ60" role="3cqZAp">
+                                        <node concept="2OqwBi" id="3KMP7S1gJ61" role="3clFbG">
+                                          <node concept="37vLTw" id="3KMP7S1gJ62" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="3KMP7S1gJ64" resolve="it" />
+                                          </node>
+                                          <node concept="3TrcHB" id="3KMP7S1gJ63" role="2OqNvi">
+                                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="gl6BB" id="3KMP7S1gJ64" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="3KMP7S1gJ65" role="1tU5fm" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2GrUjf" id="3KMP7S1gJ66" role="1urrMF">
+                          <ref role="2Gs0qQ" node="3KMP7S1gJ5N" resolve="afwijkendVeld" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="3KMP7S1gJ67" role="2GsD0m">
+                      <node concept="37vLTw" id="3KMP7S1gJ6x" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3KMP7S1gJ6s" resolve="inputs" />
+                      </node>
+                      <node concept="3zZkjj" id="3KMP7S1gJ69" role="2OqNvi">
+                        <node concept="1bVj0M" id="3KMP7S1gJ6a" role="23t8la">
+                          <node concept="3clFbS" id="3KMP7S1gJ6b" role="1bW5cS">
+                            <node concept="3clFbF" id="3KMP7S1gJ6c" role="3cqZAp">
+                              <node concept="3y3z36" id="3KMP7S1gJ6d" role="3clFbG">
+                                <node concept="2OqwBi" id="3KMP7S1gJ6e" role="3uHU7w">
+                                  <node concept="37vLTw" id="3KMP7S1gJ6f" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="3KMP7S1gJ5t" resolve="objectTypes" />
+                                  </node>
+                                  <node concept="1uHKPH" id="3KMP7S1gJ6g" role="2OqNvi" />
+                                </node>
+                                <node concept="2OqwBi" id="3KMP7S1gJ6h" role="3uHU7B">
+                                  <node concept="2WthIp" id="3KMP7S1gJ6z" role="2Oq$k0" />
+                                  <node concept="2XshWL" id="3KMP7S1gJ6j" role="2OqNvi">
+                                    <ref role="2WH_rO" node="7BFdRvvUHFd" resolve="objectType" />
+                                    <node concept="37vLTw" id="3KMP7S1gJ6k" role="2XxRq1">
+                                      <ref role="3cqZAo" node="3KMP7S1gJ6l" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="3KMP7S1gJ6l" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="3KMP7S1gJ6m" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3eOSWO" id="3KMP7S1gJ6n" role="3eO9$A">
+                  <node concept="3cmrfG" id="3KMP7S1gJ6o" role="3uHU7w">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="37vLTw" id="3KMP7S1h5jN" role="3uHU7B">
+                    <ref role="3cqZAo" node="3KMP7S1h5jI" resolve="n" />
                   </node>
                 </node>
               </node>
@@ -7155,7 +7324,7 @@
             <node concept="1YBJjd" id="7BFdRvtd_Ym" role="2Oq$k0">
               <ref role="1YBMHb" node="2a2AOY7jNuU" resolve="entrypoint" />
             </node>
-            <node concept="3TrEf2" id="7BFdRvtdCK3" role="2OqNvi">
+            <node concept="3TrEf2" id="4UYgXtX2KLV" role="2OqNvi">
               <ref role="3Tt5mk" to="ku5w:2a2AOY3ydGk" resolve="startFlow" />
             </node>
           </node>
@@ -9285,167 +9454,6 @@
         <node concept="3Tqbb2" id="7BFdRvvUNFH" role="1tU5fm">
           <ref role="ehGHo" to="ku5w:1ikyrmjHd1n" resolve="BerichtVeld" />
         </node>
-      </node>
-    </node>
-    <node concept="2XrIbr" id="5$8nGEkWk$f" role="2p_Lja">
-      <property role="TrG5h" value="checkGelijkeObjecttypes" />
-      <node concept="3cqZAl" id="5$8nGEkWqtM" role="3clF45" />
-      <node concept="3clFbS" id="5$8nGEkWk$h" role="3clF47">
-        <node concept="3cpWs8" id="5$8nGEkWqI9" role="3cqZAp">
-          <node concept="3cpWsn" id="5$8nGEkWqIa" role="3cpWs9">
-            <property role="TrG5h" value="objectTypesBijVelden" />
-            <node concept="A3Dl8" id="5$8nGEkWqIb" role="1tU5fm">
-              <node concept="3Tqbb2" id="5$8nGEkWqIc" role="A3Ik2">
-                <ref role="ehGHo" to="3ic2:$infi2rtPg" resolve="ObjectType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5$8nGEkWqId" role="33vP2m">
-              <property role="hSjvv" value="true" />
-              <node concept="2OqwBi" id="5$8nGEkWqIe" role="2Oq$k0">
-                <property role="hSjvv" value="true" />
-                <node concept="2OqwBi" id="5$8nGEkWqIf" role="2Oq$k0">
-                  <property role="hSjvv" value="true" />
-                  <node concept="37vLTw" id="5$8nGEkWzeK" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5$8nGEkWqzx" resolve="velden" />
-                  </node>
-                  <node concept="3$u5V9" id="5$8nGEkWqIo" role="2OqNvi">
-                    <node concept="1bVj0M" id="5$8nGEkWqIp" role="23t8la">
-                      <node concept="3clFbS" id="5$8nGEkWqIq" role="1bW5cS">
-                        <node concept="3clFbF" id="5$8nGEkWqIr" role="3cqZAp">
-                          <node concept="2OqwBi" id="5$8nGEkWqIs" role="3clFbG">
-                            <node concept="2WthIp" id="5$8nGEkWqIt" role="2Oq$k0" />
-                            <node concept="2XshWL" id="5$8nGEkWqIu" role="2OqNvi">
-                              <ref role="2WH_rO" node="7BFdRvvUHFd" resolve="objectType" />
-                              <node concept="37vLTw" id="5$8nGEkWqIv" role="2XxRq1">
-                                <ref role="3cqZAo" node="5$8nGEkWqIw" resolve="it" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="gl6BB" id="5$8nGEkWqIw" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="5$8nGEkWqIx" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="1KnU$U" id="5$8nGEkWqIy" role="2OqNvi" />
-              </node>
-              <node concept="1VAtEI" id="5$8nGEkWqIz" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="5$8nGEkWqI$" role="3cqZAp">
-          <node concept="3clFbS" id="5$8nGEkWqI_" role="3clFbx">
-            <node concept="2Gpval" id="5$8nGEkWqIA" role="3cqZAp">
-              <node concept="2GrKxI" id="5$8nGEkWqIB" role="2Gsz3X">
-                <property role="TrG5h" value="afwijkendVeld" />
-              </node>
-              <node concept="3clFbS" id="5$8nGEkWqIC" role="2LFqv$">
-                <node concept="2MkqsV" id="5$8nGEkWqID" role="3cqZAp">
-                  <node concept="3cpWs3" id="5$8nGEkWqIE" role="2MkJ7o">
-                    <node concept="Xl_RD" id="5$8nGEkWqIF" role="3uHU7w">
-                      <property role="Xl_RC" value="." />
-                    </node>
-                    <node concept="3cpWs3" id="5$8nGEkWqIG" role="3uHU7B">
-                      <node concept="Xl_RD" id="5$8nGEkWqIH" role="3uHU7B">
-                        <property role="Xl_RC" value="De verschillende velden moeten bij één enkel objecttype horen. Nu " />
-                      </node>
-                      <node concept="2YIFZM" id="5$8nGEkWqII" role="3uHU7w">
-                        <ref role="37wK5l" to="5iz4:2n2csM8gcRA" resolve="joinWithCommaEn" />
-                        <ref role="1Pybhc" to="5iz4:5vjARXKnVvl" resolve="StringUtil" />
-                        <node concept="2OqwBi" id="5$8nGEkWqIJ" role="37wK5m">
-                          <node concept="37vLTw" id="5$8nGEkWqIK" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5$8nGEkWqIa" resolve="objectTypesBijVelden" />
-                          </node>
-                          <node concept="3$u5V9" id="5$8nGEkWqIL" role="2OqNvi">
-                            <node concept="1bVj0M" id="5$8nGEkWqIM" role="23t8la">
-                              <node concept="3clFbS" id="5$8nGEkWqIN" role="1bW5cS">
-                                <node concept="3clFbF" id="5$8nGEkWqIO" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5$8nGEkWqIP" role="3clFbG">
-                                    <node concept="37vLTw" id="5$8nGEkWqIQ" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="5$8nGEkWqIS" resolve="it" />
-                                    </node>
-                                    <node concept="3TrcHB" id="5$8nGEkWqIR" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="gl6BB" id="5$8nGEkWqIS" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="5$8nGEkWqIT" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2GrUjf" id="5$8nGEkWqIU" role="1urrMF">
-                    <ref role="2Gs0qQ" node="5$8nGEkWqIB" resolve="afwijkendVeld" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5$8nGEkWqIV" role="2GsD0m">
-                <node concept="37vLTw" id="5$8nGEkW__M" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5$8nGEkWqzx" resolve="velden" />
-                </node>
-                <node concept="3zZkjj" id="5$8nGEkWqJ4" role="2OqNvi">
-                  <node concept="1bVj0M" id="5$8nGEkWqJ5" role="23t8la">
-                    <node concept="3clFbS" id="5$8nGEkWqJ6" role="1bW5cS">
-                      <node concept="3clFbF" id="5$8nGEkWqJ7" role="3cqZAp">
-                        <node concept="3y3z36" id="5$8nGEkWqJ8" role="3clFbG">
-                          <node concept="2OqwBi" id="5$8nGEkWqJ9" role="3uHU7w">
-                            <node concept="37vLTw" id="5$8nGEkWqJa" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5$8nGEkWqIa" resolve="objectTypesBijVelden" />
-                            </node>
-                            <node concept="1uHKPH" id="5$8nGEkWqJb" role="2OqNvi" />
-                          </node>
-                          <node concept="2OqwBi" id="5$8nGEkWqJc" role="3uHU7B">
-                            <node concept="2WthIp" id="5$8nGEkWqJd" role="2Oq$k0" />
-                            <node concept="2XshWL" id="5$8nGEkWqJe" role="2OqNvi">
-                              <ref role="2WH_rO" node="7BFdRvvUHFd" resolve="objectType" />
-                              <node concept="37vLTw" id="5$8nGEkWqJf" role="2XxRq1">
-                                <ref role="3cqZAo" node="5$8nGEkWqJg" resolve="it" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gl6BB" id="5$8nGEkWqJg" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="5$8nGEkWqJh" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3eOSWO" id="5$8nGEkWqJi" role="3clFbw">
-            <node concept="3cmrfG" id="5$8nGEkWqJj" role="3uHU7w">
-              <property role="3cmrfH" value="1" />
-            </node>
-            <node concept="2OqwBi" id="5$8nGEkWqJk" role="3uHU7B">
-              <node concept="37vLTw" id="5$8nGEkWqJl" role="2Oq$k0">
-                <ref role="3cqZAo" node="5$8nGEkWqIa" resolve="objectTypesBijVelden" />
-              </node>
-              <node concept="34oBXx" id="5$8nGEkWqJm" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="5$8nGEkWk$i" role="1B3o_S" />
-      <node concept="37vLTG" id="5$8nGEkWqzx" role="3clF46">
-        <property role="TrG5h" value="velden" />
-        <node concept="2I9FWS" id="5$8nGEkWqzw" role="1tU5fm">
-          <ref role="2I9WkF" to="ku5w:1ikyrmjHd1n" resolve="BerichtVeld" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5$8nGEkY1ZS" role="2AJF6D">
-        <ref role="2AI5Lk" to="tpd5:hNAUp6x" resolve="CheckingMethod" />
       </node>
     </node>
   </node>

--- a/solutions/test/Servicespraak/models/entrypoints@tests.mps
+++ b/solutions/test/Servicespraak/models/entrypoints@tests.mps
@@ -36,7 +36,16 @@
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
     </language>
+    <language id="09c04f52-88c5-4bd6-a481-cabab9f61ff5" name="contexts">
+      <concept id="4485080112264973245" name="contexts.structure.Witruimte" flags="ng" index="1uxNW$" />
+    </language>
     <language id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak">
+      <concept id="653687101158189440" name="regelspraak.structure.Regelgroep" flags="ng" index="2bQVlO">
+        <child id="9154144551704439187" name="inhoud" index="1HSqhF" />
+      </concept>
+      <concept id="5308348422954264413" name="regelspraak.structure.RegelsetRef" flags="ng" index="17AEQp">
+        <reference id="5308348422954265446" name="set" index="17AE6y" />
+      </concept>
       <concept id="1024280404748017953" name="regelspraak.structure.UnivOnderwerp" flags="ng" index="3_kdyS" />
       <concept id="1024280404748429508" name="regelspraak.structure.Onderwerp" flags="ngI" index="3_mD5t">
         <reference id="7647149462025448902" name="base" index="Qu8KH" />
@@ -59,6 +68,7 @@
         <property id="8879350159213016781" name="componentnaam" index="2R2JWx" />
         <property id="8879350159213016767" name="projectnaam" index="2R2JXj" />
         <property id="235016714107005849" name="serviceNamespace" index="3jS_BH" />
+        <property id="2657656834115692059" name="serviceAcroniem" index="1CIKbk" />
         <child id="2486720710064795935" name="entrypoints" index="2xxADg" />
       </concept>
       <concept id="2486720710064725693" name="servicespraak.structure.Entrypoint" flags="ng" index="2xwknM">
@@ -69,6 +79,7 @@
         <property id="8267513940666745543" name="xmlBerichtType" index="1bH1VB" />
         <property id="3136425091197698285" name="acroniem" index="3EWdbH" />
         <reference id="2486720710073441044" name="startFlow" index="2x2$1r" />
+        <child id="489580120366705953" name="regelgroep" index="2dhVIB" />
       </concept>
     </language>
     <language id="65239ca4-9057-41f8-999d-97fa1a60b298" name="besturingspraak">
@@ -326,6 +337,38 @@
             <node concept="1TM$A" id="6RoaLNA2NNl" role="7EUXB">
               <node concept="2PYRI3" id="6RoaLNA2NNm" role="3lydEf">
                 <ref role="39XzEq" to="93yo:6RoaLNA0AQA" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4UYgXtX9ahI" role="1SKRRt">
+      <node concept="2bQVlO" id="4UYgXtX4Br0" role="1qenE9">
+        <property role="TrG5h" value="Empty" />
+        <node concept="1uxNW$" id="4UYgXtX4Br1" role="1HSqhF" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="4UYgXtX9ahG" role="1SKRRt">
+      <node concept="2kTx5H" id="4UYgXtX4BqX" role="1qenE9">
+        <property role="TrG5h" value="EntrypointWithoutInputOrFlow" />
+        <property role="2R2JXj" value="i47" />
+        <property role="2R2JWx" value="test" />
+        <property role="1CIKbk" value="issue47" />
+        <property role="3jS_BH" value="https://.47.example.org" />
+        <node concept="2xwknM" id="4UYgXtX4BqY" role="2xxADg">
+          <property role="1bH1VB" value="Message" />
+          <property role="2xUFKJ" value="Request" />
+          <property role="2xUFKI" value="Response" />
+          <property role="2xUFmC" value="rekenjaar" />
+          <property role="TrG5h" value="noInput" />
+          <node concept="17AEQp" id="4UYgXtX9ahK" role="2dhVIB">
+            <ref role="17AE6y" node="4UYgXtX4Br0" resolve="Empty" />
+          </node>
+          <node concept="7CXmI" id="4UYgXtX9ahL" role="lGtFl">
+            <node concept="1TM$A" id="4UYgXtX9ahM" role="7EUXB">
+              <node concept="2PYRI3" id="3KMP7S1t5N_" role="3lydEf">
+                <ref role="39XzEq" to="93yo:4UYgXtXstHH" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
A model check was missing for service entrypoints without inputs (or a start-flow with a subject), causing the generation error: Objecttype kan niet bepaald worden a.d.h.v. invoer of flow.