### PR TITLE
Prevent XXE in service test import

### DIFF
--- a/AlefJava/alefProjectBuild/src/main/java/nl/belastingdienst/brm/alef/projectbuilder/App.java
+++ b/AlefJava/alefProjectBuild/src/main/java/nl/belastingdienst/brm/alef/projectbuilder/App.java
@@ -166,7 +166,7 @@ public final class App {
             }
             Platform.showMessage("---- >8 ---- Last lines of log file '" + logFile + "'. ---- >8 ----");
         } catch (IOException io) {
-            logger.severe("Cannot read log file '" + logFile + "': " + io.getMessage());
+            logger.severe(String.format("Cannot read log file '%s': %s", logFile, io.getMessage()));
         }
         System.exit(exitCode);
     }

--- a/AlefJava/alefProjectBuild/src/main/java/nl/belastingdienst/brm/alef/servicetest/collector/PathTraversalException.java
+++ b/AlefJava/alefProjectBuild/src/main/java/nl/belastingdienst/brm/alef/servicetest/collector/PathTraversalException.java
@@ -1,0 +1,7 @@
+package nl.belastingdienst.brm.alef.servicetest.collector;
+
+public class PathTraversalException extends RuntimeException {
+    public PathTraversalException(String causedBy) {
+        super("Path traversal caused by '" + causedBy + "'");
+    }
+}

--- a/AlefJava/alefProjectBuild/src/main/java/nl/belastingdienst/brm/alef/servicetest/collector/ServicetestCollector.java
+++ b/AlefJava/alefProjectBuild/src/main/java/nl/belastingdienst/brm/alef/servicetest/collector/ServicetestCollector.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.belastingdienst.brm.alef.servicetest.dto.ServiceTest;
 import nl.belastingdienst.brm.alef.servicetest.dto.ServiceTestSet;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -46,7 +45,7 @@ public final class ServicetestCollector {
 
         final Map<String, TestSets> services = collectTestSets(serviceInfoFiles, mapper);
 
-        writeZip(services, outputPath, mapper);
+        writeZip(services, outputPath, searchPath, mapper);
     }
 
     private static Map<String, TestSets> collectTestSets(List<Path> serviceInfoFiles, ObjectMapper mapper) throws IOException {
@@ -59,56 +58,81 @@ public final class ServicetestCollector {
             }
             TestSets testSets = services.get(data.getService());
 
-            if (data.getSoap() != null) {
-                for (ServiceTest test : data.getSoap()) {
-                    testSets.files.put(p.getParent().resolve(test.getInput()), test.getInput());
-                    testSets.files.put(p.getParent().resolve(test.getExpected()), test.getExpected());
-                }
-            }
-            if (data.getRest() != null) {
-                for (ServiceTest test : data.getRest()) {
-                    testSets.files.put(p.getParent().resolve(test.getInput()), test.getInput());
-                    testSets.files.put(p.getParent().resolve(test.getExpected()), test.getExpected());
-                }
-            }
+            processTestSets(data.getSoap(), p.getParent(), "soap/inp/", "soap/exp/", testSets);
+            processTestSets(data.getRest(), p.getParent(), "json/inp/", "json/exp/", testSets);
 
-            String relativeXsdPath = "xsd/" + new File(data.getXsd()).getName();
-            if (!testSets.files.containsValue(relativeXsdPath)) {
-                testSets.files.put(new File(data.getXsd()).toPath(), relativeXsdPath);
+            if (!data.getXsd().isEmpty()) {
+                Path xsdPath = p.getParent().resolve(Path.of(data.getXsd()));
+                String relativeXsdPath = "xsd/" + xsdPath.getFileName();
+                if (!testSets.files.containsValue(relativeXsdPath)) {
+                    testSets.files.put(xsdPath, relativeXsdPath);
+                }
+                data.setXsd(relativeXsdPath);
             }
-            data.setXsd(relativeXsdPath);
 
             testSets.testSetList.add(data);
         }
         return services;
     }
 
+    private static void processTestSets(List<ServiceTest> data, Path basePath, String inputPath, String outputPath, TestSets testSets) {
+        if (data != null) {
+            for (ServiceTest test : data) {
+                final Path inputFile = basePath.resolve(test.getInput());
+                final Path outputFile = basePath.resolve(test.getExpected());
+                final String relativeInputFilePath = inputPath + inputFile.getFileName();
+                final String relativeExpectedFilePath = outputPath + outputFile.getFileName();
+                testSets.files.put(inputFile, relativeInputFilePath);
+                testSets.files.put(outputFile, relativeExpectedFilePath);
+                test.setInput(relativeInputFilePath);
+                test.setExpected(relativeExpectedFilePath);
+            }
+        }
+    }
+
     private static void writeZip(final Map<String, TestSets> services,
                                  final Path outputPath,
+                                 final Path basePath,
                                  final ObjectMapper mapper) throws IOException {
         for (Map.Entry<String, TestSets> entry : services.entrySet()) {
-            try (FileOutputStream fos = new FileOutputStream(outputPath.resolve(entry.getKey() + ".zip").toFile(), false);
-                 ZipOutputStream zip = new ZipOutputStream(fos)) {
-                final TestSets sets = entry.getValue();
-                ZipEntry zipEntry = new ZipEntry("data.json");
-                zip.putNextEntry(zipEntry);
-                mapper.writeValue(zip, entry.getValue().testSetList);
-                zip.closeEntry();
+            if (entry.getKey() != null && !entry.getKey().isBlank()) {
+                if (!outputPath.resolve(entry.getKey() + ".zip").normalize().startsWith(outputPath.normalize())) {
+                    throw new PathTraversalException(entry.getKey());
+                }
+                try (FileOutputStream fos = new FileOutputStream(outputPath.resolve(entry.getKey() + ".zip").toFile(), false);
+                     ZipOutputStream zip = new ZipOutputStream(fos)) {
+                    final TestSets sets = entry.getValue();
+                    addMetaData(zip, sets, mapper);
 
-                final byte[] buffer = new byte[1024*1024];
-                for (Map.Entry<Path, String> file : sets.files.entrySet()) {
-                    final ZipEntry zipFileEntry = new ZipEntry(file.getValue());
-                    zip.putNextEntry(zipFileEntry);
-                    try (FileInputStream fis = new FileInputStream(file.getKey().toFile())) {
-                        int read;
-                        while ((read = fis.read(buffer, 0, buffer.length)) > 0) {
-                            zip.write(buffer, 0, read);
-                        }
-                    } finally {
-                        zip.closeEntry();
+                    for (Map.Entry<Path, String> file : sets.files.entrySet()) {
+                        addFileToZip(zip, basePath, file.getKey(), file.getValue());
                     }
                 }
             }
+        }
+    }
+
+    private static void addMetaData(final ZipOutputStream zip, final TestSets sets, final ObjectMapper mapper) throws IOException {
+        final ZipEntry zipEntry = new ZipEntry("data.json");
+        zip.putNextEntry(zipEntry);
+        mapper.writeValue(zip, sets.testSetList);
+        zip.closeEntry();
+    }
+
+    private static void addFileToZip(final ZipOutputStream zip, final Path basePath, final Path file, final String name) throws IOException {
+        final byte[] buffer = new byte[1024*1024];
+        final ZipEntry zipFileEntry = new ZipEntry(name);
+        zip.putNextEntry(zipFileEntry);
+        if (!file.normalize().toAbsolutePath().startsWith(basePath.normalize().toAbsolutePath())) {
+            throw new PathTraversalException(file.toString());
+        }
+        try (FileInputStream fis = new FileInputStream(file.toFile())) {
+            int read;
+            while ((read = fis.read(buffer, 0, buffer.length)) > 0) {
+                zip.write(buffer, 0, read);
+            }
+        } finally {
+            zip.closeEntry();
         }
     }
 }

--- a/AlefJava/alefProjectBuild/src/test/java/nl/belastingdienst/brm/alef/servicetest/collector/ServiceTestCollectorTests.java
+++ b/AlefJava/alefProjectBuild/src/test/java/nl/belastingdienst/brm/alef/servicetest/collector/ServiceTestCollectorTests.java
@@ -1,0 +1,292 @@
+package nl.belastingdienst.brm.alef.servicetest.collector;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.belastingdienst.brm.alef.projectbuilder.Platform;
+import nl.belastingdienst.brm.alef.servicetest.dto.ServiceTest;
+import nl.belastingdienst.brm.alef.servicetest.dto.ServiceTestSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class ServiceTestCollectorTests {
+    @Test
+    public void validServiceInfoTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("solutions"));
+        validServiceInfoTest(tmpFolder, rootFolder, rootFolder);
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    /**
+     * Test the case that the working dir is the root folder.
+     */
+    @Test
+    public void validWorkingDirServiceInfoTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("solutions"));
+        validServiceInfoTest(Path.of("."), tmpFolder, rootFolder);
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    private void validServiceInfoTest(Path basePath, Path outputPath, Path solutionFolder) throws IOException  {
+        final Path rootFolder = solutionFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                "test",
+                rootFolder.resolve("service.xsd"),
+                rootFolder.resolve("input.xml"),
+                rootFolder.resolve("expected.xml"),
+                rootFolder.resolve("input.json"),
+                rootFolder.resolve("expected.json"));
+
+        ServicetestCollector.collect(basePath, outputPath);
+
+        final Path resultZipFile = outputPath.resolve(Path.of("test.zip"));
+        Assert.assertTrue(Files.exists(resultZipFile));
+        validateResultZip(resultZipFile);
+    }
+
+    private void validateResultZip(final Path resultZipFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+        final List<String> zipFiles = getFilesInZip(resultZipFile);
+        Assert.assertTrue(zipFiles.contains("data.json"));
+        for (String file : zipFiles) {
+            Assert.assertFalse(file.contains(".."));
+        }
+
+        int expectedFiles = 1;
+
+        final byte[] contents = Platform.extractFromZip(resultZipFile.toFile(), "data.json");
+        List<ServiceTestSet> testSets = mapper.readValue(contents, new TypeReference<>(){});
+        for (ServiceTestSet testSet : testSets) {
+            if (!testSet.getXsd().isBlank()) {
+                Assert.assertTrue(zipFiles.contains(testSet.getXsd()));
+                expectedFiles++;
+            }
+            for (ServiceTest test : testSet.getSoap()) {
+                Assert.assertTrue(zipFiles.contains(test.getInput()));
+                Assert.assertTrue(zipFiles.contains(test.getExpected()));
+                expectedFiles += 2;
+            }
+            for (ServiceTest test : testSet.getRest()) {
+                Assert.assertTrue(zipFiles.contains(test.getInput()));
+                Assert.assertTrue(zipFiles.contains(test.getExpected()));
+                expectedFiles += 2;
+            }
+        }
+
+        Assert.assertEquals(expectedFiles, zipFiles.size());
+    }
+
+    private List<String> getFilesInZip(Path zipFile) {
+        List<String> files = new ArrayList<>();
+        try (FileInputStream fis = new FileInputStream(zipFile.toFile());
+             ZipInputStream zip = new ZipInputStream(fis)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                files.add(entry.getName());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return files;
+    }
+
+    @Test
+    public void pathTraversalServiceNameTest() throws IOException {
+        final String serviceName = Path.of("..", "test-service").toString().replace("\\", "\\\\");
+
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                serviceName,
+                tmpFolder.resolve("service.xsd"),
+                rootFolder.resolve("input.xml"),
+                rootFolder.resolve("expected.xml"),
+                rootFolder.resolve("input.json"),
+                rootFolder.resolve("expected.json"));
+
+        PathTraversalException e = Assert.assertThrows(PathTraversalException.class, () -> ServicetestCollector.collect(rootFolder, rootFolder));
+        Assert.assertTrue(e.getMessage().contains(serviceName));
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    @Test
+    public void pathTraversalXSDTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                "test",
+                tmpFolder.resolve("service.xsd"),
+                rootFolder.resolve("input.xml"),
+                rootFolder.resolve("expected.xml"),
+                rootFolder.resolve("input.json"),
+                rootFolder.resolve("expected.json"));
+
+        PathTraversalException e = Assert.assertThrows(PathTraversalException.class, () -> ServicetestCollector.collect(rootFolder, rootFolder));
+        Assert.assertTrue(e.getMessage().contains("service.xsd"));
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    @Test
+    public void pathTraversalSoapInputTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                "test",
+                rootFolder.resolve("service.xsd"),
+                tmpFolder.resolve("input.xml"),
+                rootFolder.resolve("expected.xml"),
+                rootFolder.resolve("input.json"),
+                rootFolder.resolve("expected.json"));
+
+        PathTraversalException e = Assert.assertThrows(PathTraversalException.class, () -> ServicetestCollector.collect(rootFolder, rootFolder));
+        Assert.assertTrue(e.getMessage().contains("input.xml"));
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    @Test
+    public void pathTraversalSoapExpectedTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                "test",
+                rootFolder.resolve("service.xsd"),
+                rootFolder.resolve("input.xml"),
+                tmpFolder.resolve("expected.xml"),
+                rootFolder.resolve("input.json"),
+                rootFolder.resolve("expected.json"));
+
+        PathTraversalException e = Assert.assertThrows(PathTraversalException.class, () -> ServicetestCollector.collect(rootFolder, rootFolder));
+        Assert.assertTrue(e.getMessage().contains("expected.xml"));
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    @Test
+    public void pathTraversalRestInputTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                "test",
+                rootFolder.resolve("service.xsd"),
+                rootFolder.resolve("input.xml"),
+                rootFolder.resolve("expected.xml"),
+                tmpFolder.resolve("input.json"),
+                rootFolder.resolve("expected.json"));
+
+        PathTraversalException e = Assert.assertThrows(PathTraversalException.class, () -> ServicetestCollector.collect(rootFolder, rootFolder));
+        Assert.assertTrue(e.getMessage().contains("input.json"));
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    @Test
+    public void pathTraversalRestExpectedTest() throws IOException {
+        final Path tmpFolder = createTempFolder();
+        final Path rootFolder = tmpFolder.resolve(Path.of("root"));
+        final Path sourceGenFolder = rootFolder.resolve(Path.of("source_gen"));
+        Files.createDirectories(sourceGenFolder);
+
+        buildServiceInfo(
+                sourceGenFolder.resolve(Path.of("servicetestinfo-test.json")),
+                "test",
+                "test",
+                rootFolder.resolve("service.xsd"),
+                rootFolder.resolve("input.xml"),
+                rootFolder.resolve("expected.xml"),
+                rootFolder.resolve("input.json"),
+                tmpFolder.resolve("expected.json"));
+
+        PathTraversalException e = Assert.assertThrows(PathTraversalException.class, () -> ServicetestCollector.collect(rootFolder, rootFolder));
+        Assert.assertTrue(e.getMessage().contains("expected.json"));
+        Platform.deleteFolder(tmpFolder);
+    }
+
+    private Path createTempFolder() throws IOException {
+        final Path tmpFolder = Path.of(".", "tmp");
+        if (Files.exists(tmpFolder)) {
+            Platform.deleteFolder(tmpFolder);
+        }
+        Assert.assertTrue("Make temp folder", tmpFolder.toFile().mkdir());
+        return tmpFolder;
+    }
+
+    private void buildServiceInfo(final Path serviceInfo, final String testSet, final String service, final Path xsd, final Path soapInput, final Path soapExpected, final Path restInput, final Path restExpected) throws IOException {
+        StringBuilder content = new StringBuilder();
+        content.append("{\"testSet\": \"")
+                .append(testSet).append("\", \"service\": \"")
+                .append(service).append("\", ");
+        buildFileField(serviceInfo, content, "xsd", xsd);
+        buildMessages(serviceInfo, content, "soap", soapInput, soapExpected);
+        buildMessages(serviceInfo, content, "rest", restInput, restExpected);
+        content.append("}");
+        Files.writeString(serviceInfo, content.toString());
+    }
+
+    private void buildMessages(final Path serviceInfo, final StringBuilder content, final String kind, final Path input, final Path expected) throws IOException {
+        if (input != null || expected != null) {
+            content.append(", \"").append(kind).append("\": [{");
+            if (input != null) {
+                buildFileField(serviceInfo, content, "input", input);
+            }
+            if (expected != null) {
+                if (input != null) content.append(",");
+                buildFileField(serviceInfo, content, "expected", expected);
+            }
+            content.append("}]");
+        }
+    }
+
+    private void buildFileField(final Path serviceInfo, final StringBuilder content, final String fieldName, final Path file) throws IOException {
+        content.append("\"").append(fieldName).append("\": \"");
+        if (file != null) {
+            Files.writeString(file, "empty");
+            content.append(relativePath(serviceInfo.getParent(), file));
+        }
+        content.append("\"");
+    }
+
+    private String relativePath(final Path basePath, final Path path) {
+        return basePath.relativize(path).toString().replace("\\", "\\\\");
+    }
+}

--- a/AlefJava/alefProjectBuild/src/test/java/nl/belastingdienst/brm/alef/servicetest/runner/ServiceTestRunnerTests.java
+++ b/AlefJava/alefProjectBuild/src/test/java/nl/belastingdienst/brm/alef/servicetest/runner/ServiceTestRunnerTests.java
@@ -1,0 +1,199 @@
+package nl.belastingdienst.brm.alef.servicetest.runner;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nl.belastingdienst.brm.alef.servicetest.dto.ServiceTest;
+import nl.belastingdienst.brm.alef.servicetest.dto.ServiceTestSet;
+import nl.belastingdienst.brm.alef.servicetest_runtime.ServletServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ServiceTestRunnerTests {
+    private final String xsd = """
+                    <?xml version="1.0" encoding="UTF-8" ?>
+                    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="https://example.org/message" xmlns:m="https://example.org/message">
+                      <xs:element name="message" type="m:Message" />
+                      <xs:complexType name="Message">
+                        <xs:sequence>
+                          <xs:element name="request" type="m:Request" />
+                          <xs:element name="response" type="m:Response" minOccurs="0" />
+                        </xs:sequence>
+                      </xs:complexType>
+                      <xs:complexType name="Request">
+                        <xs:sequence>
+                          <xs:element name="name" type="xs:string" />
+                        </xs:sequence>
+                      </xs:complexType>
+                      <xs:complexType name="Response">
+                        <xs:sequence>
+                          <xs:element name="result" type="xs:string" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:schema>""";
+    final String validMessage = """
+                <?xml version="1.0"?>
+                <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:m="https://example.org">
+                  <soap:Header />
+                  <soap:Body>
+                    <m:message>
+                      <request>
+                        <name>test</name>
+                      </request>
+                      <response>
+                        <result>0</result>
+                      </response>
+                    </m:message>
+                  </soap:Body>
+                </soap:Envelope>
+                """;
+    final String invalidMessage = """
+                <?xml version="1.0"?>
+                <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:m="https://example.org">
+                  <soap:Header />
+                  <soap:Body>
+                    <m:message>
+                      <request>
+                        <!-- name is missing -->
+                      </request>
+                      <response>
+                        <result>0</result>
+                      </response>
+                    </m:message>
+                  </soap:Body>
+                </soap:Envelope>
+                """;
+
+    private final Path testZip = Path.of(".", "test.zip");
+
+    @Before
+    public void before() {
+        if (tryDeleteIfExists(testZip)) {
+            System.out.println("WARN: Removed " + testZip);
+        }
+    }
+
+    @After
+    public void after() {
+        tryDeleteIfExists(Path.of("actual-test.json"));
+        tryDeleteIfExists(Path.of("actual-test.xml"));
+        tryDeleteIfExists(testZip);
+    }
+
+    @Test
+    public void validSoapMessageTest() throws IOException {
+        final String entryPoint = "TestEntrypoint";
+        buildZip(testZip, entryPoint, validMessage, validMessage, xsd);
+
+        final List<String> requests = new ArrayList<>();
+        final ServletServer servletServer = buildServer(validMessage, requests);
+
+        ServicetestRunner runner = new ServicetestRunner(servletServer.getUrl(), "");
+        Assert.assertTrue(runner.run(testZip));
+
+        servletServer.stop();
+
+        Assert.assertEquals(1, requests.size());
+        Assert.assertEquals(validMessage.trim(), requests.get(0));
+
+        Files.delete(testZip);
+    }
+
+    @Test
+    public void invalidSoapMessageTest() throws IOException {
+        final String entryPoint = "TestEntrypoint";
+        buildZip(testZip, entryPoint, validMessage, validMessage, xsd);
+
+        final List<String> requests = new ArrayList<>();
+        final ServletServer servletServer = buildServer(invalidMessage, requests);
+
+        ServicetestRunner runner = new ServicetestRunner(servletServer.getUrl(), "");
+        Assert.assertFalse(runner.run(testZip));
+
+        servletServer.stop();
+
+        Assert.assertEquals(1, requests.size());
+        Assert.assertEquals(validMessage.trim(), requests.get(0));
+
+        Files.delete(testZip);
+    }
+
+    private ServletServer buildServer(final String response, final List<String> requests) {
+        final HttpServlet servlet = new HttpServlet() {
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                resp.getWriter().write(response);
+                requests.add(new String(req.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+            }
+        };
+        return new ServletServer(servlet);
+    }
+
+    private static void buildZip(final Path zipFile, final String entryPoint, final String inputMessage, final String outputMessage, final String xsd) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+        final List<ServiceTestSet> testSets = buildServiceTestSets(entryPoint);
+
+        try (FileOutputStream fos = new FileOutputStream(zipFile.toFile(), false);
+             ZipOutputStream zip = new ZipOutputStream(fos)) {
+            addFileToZip(zip, "data.json", mapper.writeValueAsString(testSets));
+            addFileToZip(zip, "soap/inp/test.xml", inputMessage);
+            addFileToZip(zip, "soap/exp/test.xml", outputMessage);
+            addFileToZip(zip, "xsd/service.xsd", xsd);
+        }
+    }
+
+    private static List<ServiceTestSet> buildServiceTestSets(final String entryPoint) {
+        final List<ServiceTestSet> testSets = new ArrayList<>();
+
+        ServiceTestSet testSet = new ServiceTestSet();
+        testSet.setService("TestService");
+        testSet.setEntrypoint(entryPoint);
+        testSet.setXsd("xsd/service.xsd");
+        testSet.setMessageNamespace("https://example.org/message");
+        testSet.setXsdMessageName("message");
+        testSet.setRequestMessageName("message");
+        testSet.setResponseMessageName("message");
+
+        List<ServiceTest> soapTests = new ArrayList<>();
+
+        ServiceTest input = new ServiceTest();
+        input.setInput("soap/inp/test.xml");
+        input.setExpected("soap/exp/test.xml");
+
+        soapTests.add(input);
+
+        testSet.setSoap(soapTests);
+        testSets.add(testSet);
+        return testSets;
+    }
+
+    private static void addFileToZip(final ZipOutputStream zip, final String name, final String content) throws IOException {
+        final ZipEntry zipEntry = new ZipEntry(name);
+        zip.putNextEntry(zipEntry);
+        zip.write(content.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+    }
+
+    private static boolean tryDeleteIfExists(final Path path) {
+        try {
+            return Files.deleteIfExists(path);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/AlefJava/serviceTestRuntime/src/main/java/nl/belastingdienst/brm/alef/servicetest_runtime/ServerException.java
+++ b/AlefJava/serviceTestRuntime/src/main/java/nl/belastingdienst/brm/alef/servicetest_runtime/ServerException.java
@@ -1,0 +1,7 @@
+package nl.belastingdienst.brm.alef.servicetest_runtime;
+
+public class ServerException extends RuntimeException {
+    public ServerException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/AlefJava/serviceTestRuntime/src/main/java/nl/belastingdienst/brm/alef/servicetest_runtime/ServletServer.java
+++ b/AlefJava/serviceTestRuntime/src/main/java/nl/belastingdienst/brm/alef/servicetest_runtime/ServletServer.java
@@ -1,19 +1,17 @@
 package nl.belastingdienst.brm.alef.servicetest_runtime;
 
+import jakarta.servlet.http.HttpServlet;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.http.spi.DelegatingThreadPool;
-import org.eclipse.jetty.http.spi.JettyHttpServerProvider;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
-import jakarta.xml.ws.Endpoint;
-
-public class EndpointServer {
+public class ServletServer {
     private final Server jettyServer;
     private final ServerConnector connector;
 
-    public EndpointServer(Object endpoint, String contextPath) {
+    public ServletServer(HttpServlet servlet) {
         jettyServer = new Server(new DelegatingThreadPool(new QueuedThreadPool()));
 
         connector = new ServerConnector(jettyServer);
@@ -21,21 +19,17 @@ public class EndpointServer {
         jettyServer.addConnector(connector);
         jettyServer.setStopAtShutdown(true);
 
-        ContextHandlerCollection context = new ContextHandlerCollection();
-
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
         jettyServer.setHandler(context);
 
-        System.setProperty("com.sun.net.httpserver.HttpServerProvider", "org.eclipse.jetty.http.spi.JettyHttpServerProvider");
-
-        JettyHttpServerProvider.setServer(jettyServer);
+        context.addServlet(servlet, "/*");
 
         try {
             jettyServer.start();
         } catch (Exception e) {
             throw new ServerException("Can't start server", e);
         }
-
-        Endpoint.publish(getUrl() + contextPath, endpoint);
     }
 
     public void stop() {

--- a/AlefJava/serviceTestRuntime/src/main/java/nl/belastingdienst/brm/alef/servicetest_runtime/WarServer.java
+++ b/AlefJava/serviceTestRuntime/src/main/java/nl/belastingdienst/brm/alef/servicetest_runtime/WarServer.java
@@ -12,11 +12,6 @@ public class WarServer {
     private final Server jettyServer;
     private final ServerConnector connector;
 
-    private static final class ServerException extends RuntimeException {
-        public ServerException(String message, Exception cause) {
-            super(message, cause);
-        }
-    }
     public WarServer(String warPath, Map<String, Object> env) {
         jettyServer = new Server();
         

--- a/languages/merlinTests/generator/templates/merlinTests.generator.templates@generator.mps
+++ b/languages/merlinTests/generator/templates/merlinTests.generator.templates@generator.mps
@@ -7762,6 +7762,15 @@
   </node>
   <node concept="312cEu" id="3$2FopMT4yc">
     <property role="TrG5h" value="MerlinServiceTestSet" />
+    <node concept="Wx3nA" id="27zx100GOF4" role="jymVt">
+      <property role="TrG5h" value="DISALLOW_DOCTYPE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="17QB3L" id="27zx100H22p" role="1tU5fm" />
+      <node concept="Xl_RD" id="27zx100GOF6" role="33vP2m">
+        <property role="Xl_RC" value="http://apache.org/xml/features/disallow-doctype-decl" />
+      </node>
+      <node concept="3Tm6S6" id="27zx100GOF7" role="1B3o_S" />
+    </node>
     <node concept="Wx3nA" id="3IpLaSx9dPf" role="jymVt">
       <property role="TrG5h" value="warServer" />
       <node concept="3uibUv" id="3IpLaSx9dPi" role="1tU5fm">
@@ -9455,6 +9464,22 @@
             <node concept="liA8E" id="5A$uEIv76f_" role="2OqNvi">
               <ref role="37wK5l" to="vpqd:~DocumentBuilderFactory.setNamespaceAware(boolean)" resolve="setNamespaceAware" />
               <node concept="3clFbT" id="5A$uEIv76fA" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="27zx100GpHk" role="3cqZAp">
+          <node concept="2OqwBi" id="27zx100GDJn" role="3clFbG">
+            <node concept="37vLTw" id="27zx100G$Pl" role="2Oq$k0">
+              <ref role="3cqZAo" node="5A$uEIv76fv" resolve="docBuilderFactory" />
+            </node>
+            <node concept="liA8E" id="27zx100GDJo" role="2OqNvi">
+              <ref role="37wK5l" to="vpqd:~DocumentBuilderFactory.setFeature(java.lang.String,boolean)" resolve="setFeature" />
+              <node concept="37vLTw" id="27zx100GDJp" role="37wK5m">
+                <ref role="3cqZAo" node="27zx100GOF4" resolve="DISALLOW_DOCTYPE" />
+              </node>
+              <node concept="3clFbT" id="27zx100GDJv" role="37wK5m">
                 <property role="3clFbU" value="true" />
               </node>
             </node>

--- a/languages/validatie/languageModels/testspraak/plugin.mps
+++ b/languages/validatie/languageModels/testspraak/plugin.mps
@@ -15,6 +15,8 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -87,8 +89,8 @@
     <import index="i51s" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.lang.smodel.generator.smodelAdapter(MPS.Core/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
-    <import index="mk90" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" implicit="true" />
-    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" implicit="true" />
+    <import index="mk90" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" />
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -8631,7 +8633,16 @@
   <node concept="312cEu" id="1Uc5WZucEUQ">
     <property role="TrG5h" value="ServiceTestImport" />
     <property role="3GE5qa" value="ImportXMLAlsServiceTest" />
-    <node concept="2tJIrI" id="1Uc5WZucEVC" role="jymVt" />
+    <node concept="Wx3nA" id="27zx100GOF4" role="jymVt">
+      <property role="TrG5h" value="DISALLOW_DOCTYPE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="17QB3L" id="27zx100H22p" role="1tU5fm" />
+      <node concept="Xl_RD" id="27zx100GOF6" role="33vP2m">
+        <property role="Xl_RC" value="http://apache.org/xml/features/disallow-doctype-decl" />
+      </node>
+      <node concept="3Tm6S6" id="27zx100GOF7" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="27zx100HPn_" role="jymVt" />
     <node concept="2YIFZL" id="1Uc5WZucEVD" role="jymVt">
       <property role="TrG5h" value="getDocAndValidate" />
       <node concept="3clFbS" id="1Uc5WZucEVE" role="3clF47">
@@ -8911,6 +8922,22 @@
                     <node concept="37vLTw" id="1Uc5WZucEWG" role="37wK5m">
                       <ref role="3cqZAo" node="1Uc5WZucEWy" resolve="xsdFactory" />
                     </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="27zx100HKAX" role="3cqZAp">
+              <node concept="2OqwBi" id="27zx100HN1Y" role="3clFbG">
+                <node concept="37vLTw" id="27zx100HMzA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1Uc5WZucEWC" resolve="sb" />
+                </node>
+                <node concept="liA8E" id="27zx100HN1Z" role="2OqNvi">
+                  <ref role="37wK5l" to="qq98:~SAXBuilder.setFeature(java.lang.String,boolean)" resolve="setFeature" />
+                  <node concept="37vLTw" id="27zx100HVKU" role="37wK5m">
+                    <ref role="3cqZAo" node="27zx100GOF4" resolve="DISALLOW_DOCTYPE" />
+                  </node>
+                  <node concept="3clFbT" id="27zx100HXdl" role="37wK5m">
+                    <property role="3clFbU" value="true" />
                   </node>
                 </node>
               </node>

--- a/solutions/Test_Spraken/models/Test_Spraken.ALEF3356.mps
+++ b/solutions/Test_Spraken/models/Test_Spraken.ALEF3356.mps
@@ -373,7 +373,7 @@
     <property role="2R2JXj" value="alf" />
     <property role="2R2JWx" value="toka3356" />
     <property role="1CIKbG" value="https://example.org/Sd__alef3356" />
-    <property role="3jS_BH" value="http://toka3356.belastingdienst.nl" />
+    <property role="3jS_BH" value="http://toka3356.example.org" />
     <property role="1CIKbk" value="rssd_alef3356" />
     <node concept="3AW6rv" id="40sycsKs5a2" role="21XpMX">
       <node concept="THod0" id="40sycsKs5as" role="3AW66m" />

--- a/solutions/pomUtils/models/pomUtils.pomUtils.mps
+++ b/solutions/pomUtils/models/pomUtils.pomUtils.mps
@@ -36,6 +36,7 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -48,6 +49,7 @@
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -73,6 +75,9 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -147,6 +152,15 @@
   </registry>
   <node concept="312cEu" id="15q2X2JfRkx">
     <property role="TrG5h" value="PomUtils" />
+    <node concept="Wx3nA" id="27zx100GOF4" role="jymVt">
+      <property role="TrG5h" value="DISALLOW_DOCTYPE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="17QB3L" id="27zx100H22p" role="1tU5fm" />
+      <node concept="Xl_RD" id="27zx100GOF6" role="33vP2m">
+        <property role="Xl_RC" value="http://apache.org/xml/features/disallow-doctype-decl" />
+      </node>
+      <node concept="3Tm6S6" id="27zx100GOF7" role="1B3o_S" />
+    </node>
     <node concept="2tJIrI" id="5Qq9WE7gb97" role="jymVt" />
     <node concept="2YIFZL" id="5Qq9WE7geUO" role="jymVt">
       <property role="TrG5h" value="getPomFile" />
@@ -330,6 +344,35 @@
                 <node concept="2YIFZM" id="NfRRTTGHSp" role="33vP2m">
                   <ref role="37wK5l" to="vpqd:~DocumentBuilderFactory.newInstance()" resolve="newInstance" />
                   <ref role="1Pybhc" to="vpqd:~DocumentBuilderFactory" resolve="DocumentBuilderFactory" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5A$uEIv76fy" role="3cqZAp">
+              <node concept="2OqwBi" id="5A$uEIv76fz" role="3clFbG">
+                <node concept="37vLTw" id="5A$uEIv76f$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="NfRRTTGHSn" resolve="documentBuilderFactory" />
+                </node>
+                <node concept="liA8E" id="5A$uEIv76f_" role="2OqNvi">
+                  <ref role="37wK5l" to="vpqd:~DocumentBuilderFactory.setNamespaceAware(boolean)" resolve="setNamespaceAware" />
+                  <node concept="3clFbT" id="5A$uEIv76fA" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="27zx100GpHk" role="3cqZAp">
+              <node concept="2OqwBi" id="27zx100GDJn" role="3clFbG">
+                <node concept="37vLTw" id="27zx100G$Pl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="NfRRTTGHSn" resolve="documentBuilderFactory" />
+                </node>
+                <node concept="liA8E" id="27zx100GDJo" role="2OqNvi">
+                  <ref role="37wK5l" to="vpqd:~DocumentBuilderFactory.setFeature(java.lang.String,boolean)" resolve="setFeature" />
+                  <node concept="37vLTw" id="27zx101bibM" role="37wK5m">
+                    <ref role="3cqZAo" node="27zx100GOF4" resolve="DISALLOW_DOCTYPE" />
+                  </node>
+                  <node concept="3clFbT" id="27zx100GDJv" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
                 </node>
               </node>
             </node>


### PR DESCRIPTION
Several XXE security finding have been resolved, including import of service tests. This does not apply to generated services, but use this new version when importing SOAP-messages from untrusted sources as service tests.