### PR TITLE
#69: dedup rulesets

### DIFF
--- a/languages/validatie/languageModels/testspraak.migration.mps
+++ b/languages/validatie/languageModels/testspraak.migration.mps
@@ -16,6 +16,7 @@
     <use id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <devkit ref="2787ae0c-1f54-4fbf-b0b7-caf2b5beecbc(jetbrains.mps.devkit.aspect.migration)" />
   </languages>
   <imports>
@@ -48,6 +49,7 @@
     <import index="txb8" ref="r:6d537c47-71e0-4074-bdff-6df0d77b3827(servicespraak.behavior)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="2vij" ref="09737df8-57b5-428f-9399-89f414a94263/java:nl.belastingdienst.alef_runtime(alef.runtime/)" />
+    <import index="5nyn" ref="r:70cf410c-6e25-457a-bade-ee96d00bdb6f(testspraak.typesystem)" />
     <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" implicit="true" />
   </imports>
   <registry>
@@ -446,6 +448,13 @@
         <child id="4234138103881610935" name="scope" index="L3pyr" />
         <child id="4234138103881610892" name="stmts" index="L3pyw" />
       </concept>
+      <concept id="4307205004131544317" name="jetbrains.mps.lang.smodel.query.structure.QueryExpression" flags="ng" index="1dNuzs">
+        <child id="4307205004132279624" name="parameter" index="1dOa5D" />
+      </concept>
+      <concept id="4307205004132277753" name="jetbrains.mps.lang.smodel.query.structure.QueryParameterList" flags="ng" index="1dO9Bo">
+        <child id="4307205004141421222" name="parameter" index="1dp2q7" />
+      </concept>
+      <concept id="677787792397344112" name="jetbrains.mps.lang.smodel.query.structure.QueryParameterExact" flags="ng" index="3Z_Q4n" />
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
@@ -524,6 +533,7 @@
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
       <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
@@ -9464,6 +9474,204 @@
       <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
     </node>
     <node concept="3uibUv" id="4SUgeorPBpz" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
+    </node>
+  </node>
+  <node concept="3SyAh_" id="4_RmGxyBqVo">
+    <property role="qMTe8" value="23" />
+    <property role="TrG5h" value="DeduplicateTeTestenRegelset" />
+    <node concept="3Tm1VV" id="4_RmGxyBqVp" role="1B3o_S" />
+    <node concept="3tTeZs" id="4_RmGxyBqVq" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="4_RmGxyBqVr" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="4_RmGxyBqVs" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="4_RmGxyBqVt" role="jymVt" />
+    <node concept="3tYpMH" id="4_RmGxyBqVu" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="4_RmGxyBqVv" role="1B3o_S" />
+      <node concept="10P_77" id="4_RmGxyBqVw" role="1tU5fm" />
+    </node>
+    <node concept="3tYpXE" id="4_RmGxyDg7b" role="jymVt">
+      <property role="TrG5h" value="description" />
+      <property role="3tYpXF" value="Dedupliceer Declaratieve Flows naar RegelgroepBundels en TeTestenRegelgroepen naar TeTestenRegelsetsp" />
+      <ref role="25KYV2" to="slm6:1_lSsE3RFpE" resolve="description" />
+      <node concept="3Tm1VV" id="4_RmGxyDg7d" role="1B3o_S" />
+      <node concept="17QB3L" id="4_RmGxyDg7e" role="1tU5fm" />
+    </node>
+    <node concept="q3mfD" id="4_RmGxyBqVy" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="4_RmGxyBqV$" role="1B3o_S" />
+      <node concept="3clFbS" id="4_RmGxyBqVA" role="3clF47">
+        <node concept="L3pyB" id="4_RmGxyBLt9" role="3cqZAp">
+          <node concept="3clFbS" id="4_RmGxyBLta" role="L3pyw">
+            <node concept="2Gpval" id="4_RmGxyCAsS" role="3cqZAp">
+              <node concept="2GrKxI" id="4_RmGxyCAsU" role="2Gsz3X">
+                <property role="TrG5h" value="node" />
+              </node>
+              <node concept="3clFbS" id="4_RmGxyCAsY" role="2LFqv$">
+                <node concept="3cpWs8" id="4_RmGxyw2KY" role="3cqZAp">
+                  <node concept="3cpWsn" id="4_RmGxyw2KZ" role="3cpWs9">
+                    <property role="TrG5h" value="seen" />
+                    <property role="3TUv4t" value="true" />
+                    <node concept="2hMVRd" id="4_RmGxyw2Ij" role="1tU5fm">
+                      <node concept="3Tqbb2" id="4_RmGxyw2Im" role="2hN53Y">
+                        <ref role="ehGHo" to="m234:3B5pq73i0gc" resolve="IRegelSet" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="4_RmGxyw2L0" role="33vP2m">
+                      <node concept="2i4dXS" id="4_RmGxyw2L1" role="2ShVmc">
+                        <node concept="3Tqbb2" id="4_RmGxyw2L2" role="HW$YZ">
+                          <ref role="ehGHo" to="m234:3B5pq73i0gc" resolve="IRegelSet" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="4_RmGxy$Hqn" role="3cqZAp">
+                  <node concept="3cpWsn" id="4_RmGxy$Hqo" role="3cpWs9">
+                    <property role="TrG5h" value="duplicates" />
+                    <property role="3TUv4t" value="true" />
+                    <node concept="2I9FWS" id="4_RmGxyB0U2" role="1tU5fm">
+                      <ref role="2I9WkF" to="m234:4AF2Ggecqtt" resolve="RegelsetRef" />
+                    </node>
+                    <node concept="2ShNRf" id="4_RmGxy$Hqr" role="33vP2m">
+                      <node concept="2T8Vx0" id="4_RmGxyB9fx" role="2ShVmc">
+                        <node concept="2I9FWS" id="4_RmGxyB9f$" role="2T96Bj">
+                          <ref role="2I9WkF" to="m234:4AF2Ggecqtt" resolve="RegelsetRef" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="4_RmGxyzDGg" role="3cqZAp">
+                  <node concept="2GrKxI" id="4_RmGxyzDGi" role="2Gsz3X">
+                    <property role="TrG5h" value="set" />
+                  </node>
+                  <node concept="2OqwBi" id="4_RmGxyzKIr" role="2GsD0m">
+                    <node concept="2GrUjf" id="4_RmGxyCSL0" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="4_RmGxyCAsU" resolve="node" />
+                    </node>
+                    <node concept="3Tsc0h" id="4_RmGxyzO_v" role="2OqNvi">
+                      <ref role="3TtcxE" to="6ldf:3B5pq75D8pr" resolve="sets" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="4_RmGxyzDGm" role="2LFqv$">
+                    <node concept="3clFbJ" id="4_RmGxyzSvR" role="3cqZAp">
+                      <node concept="2OqwBi" id="4_RmGxy$fYy" role="3clFbw">
+                        <node concept="37vLTw" id="4_RmGxy$fYz" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4_RmGxyw2KZ" resolve="seen" />
+                        </node>
+                        <node concept="3JPx81" id="4_RmGxy$fY$" role="2OqNvi">
+                          <node concept="2OqwBi" id="4_RmGxy$jy4" role="25WWJ7">
+                            <node concept="2GrUjf" id="4_RmGxy$fY_" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="4_RmGxyzDGi" resolve="set" />
+                            </node>
+                            <node concept="3TrEf2" id="4_RmGxy$oTt" role="2OqNvi">
+                              <ref role="3Tt5mk" to="m234:4AF2GgecqHA" resolve="set" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="4_RmGxyzSvT" role="3clFbx">
+                        <node concept="3clFbF" id="4_RmGxy$YYt" role="3cqZAp">
+                          <node concept="2OqwBi" id="4_RmGxy_00D" role="3clFbG">
+                            <node concept="37vLTw" id="4_RmGxy$YYs" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_RmGxy$Hqo" resolve="duplicates" />
+                            </node>
+                            <node concept="TSZUe" id="4_RmGxy_4eX" role="2OqNvi">
+                              <node concept="2GrUjf" id="4_RmGxy_4go" role="25WWJ7">
+                                <ref role="2Gs0qQ" node="4_RmGxyzDGi" resolve="set" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="9aQIb" id="4_RmGxyAeo4" role="9aQIa">
+                        <node concept="3clFbS" id="4_RmGxyAeo5" role="9aQI4">
+                          <node concept="3clFbF" id="4_RmGxyAhSX" role="3cqZAp">
+                            <node concept="2OqwBi" id="4_RmGxyAltS" role="3clFbG">
+                              <node concept="37vLTw" id="4_RmGxyAhSW" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4_RmGxyw2KZ" resolve="seen" />
+                              </node>
+                              <node concept="TSZUe" id="4_RmGxyApWJ" role="2OqNvi">
+                                <node concept="2OqwBi" id="4_RmGxyAtyk" role="25WWJ7">
+                                  <node concept="2GrUjf" id="4_RmGxyAtmf" role="2Oq$k0">
+                                    <ref role="2Gs0qQ" node="4_RmGxyzDGi" resolve="set" />
+                                  </node>
+                                  <node concept="3TrEf2" id="4_RmGxyAxYV" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="m234:4AF2GgecqHA" resolve="set" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4_RmGxyzmez" role="3cqZAp">
+                  <node concept="2OqwBi" id="4_RmGxyzokX" role="3clFbG">
+                    <node concept="2OqwBi" id="4_RmGxyzmqZ" role="2Oq$k0">
+                      <node concept="2GrUjf" id="4_RmGxyCWA5" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="4_RmGxyCAsU" resolve="node" />
+                      </node>
+                      <node concept="3Tsc0h" id="4_RmGxyznMr" role="2OqNvi">
+                        <ref role="3TtcxE" to="6ldf:3B5pq75D8pr" resolve="sets" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4_RmGxy_kLc" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~List.removeAll(java.util.Collection)" resolve="removeAll" />
+                      <node concept="37vLTw" id="4_RmGxy_s6I" role="37wK5m">
+                        <ref role="3cqZAo" node="4_RmGxy$Hqo" resolve="duplicates" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="qVDSY" id="4_RmGxyCk$w" role="2GsD0m">
+                <node concept="chp4Y" id="4_RmGxyCopg" role="qVDSX">
+                  <ref role="cht4Q" to="6ldf:3B5pq75D6L6" resolve="TeTestenRegelset" />
+                </node>
+                <node concept="1dO9Bo" id="4_RmGxyDbH1" role="1dOa5D">
+                  <node concept="3Z_Q4n" id="4_RmGxyDbH2" role="1dp2q7" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="4_RmGxyBLuq" role="L3pyr">
+            <ref role="3cqZAo" node="4_RmGxyBqVC" resolve="m" />
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="4_RmGxyBqVC" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="4_RmGxyBqVB" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="4_RmGxyBqVD" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="4_RmGxyBqVy" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="4_RmGxyBqVE" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="4_RmGxyBqVJ" role="1zkMxy">
       <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>

--- a/languages/validatie/testspraak.mpl
+++ b/languages/validatie/testspraak.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="testspraak" uuid="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" languageVersion="23" moduleVersion="15">
+<language namespace="testspraak" uuid="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" languageVersion="24" moduleVersion="15">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="languageModels" />

--- a/solutions/ALEF_Testen/ALEF_Testen.msd
+++ b/solutions/ALEF_Testen/ALEF_Testen.msd
@@ -78,7 +78,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/ALEF_Testen/models/ALEF_Testen.ALEF3740@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.ALEF3740@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
   </languages>
   <imports>

--- a/solutions/ALEF_Testen/models/ALEF_Testen.ALEFS811@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.ALEFS811@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="09c04f52-88c5-4bd6-a481-cabab9f61ff5" name="contexts" version="0" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />

--- a/solutions/ALEF_Testen/models/ALEF_Testen.RekenenEnVergelijkenMetLeeg@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.RekenenEnVergelijkenMetLeeg@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>

--- a/solutions/ALEF_Testen/models/ALEF_Testen.TestSetMetRegelEnParam_unittest@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.TestSetMetRegelEnParam_unittest@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="m68c" ref="r:651e53ca-23f3-4df5-8764-f83b7768e808(ALEF_Testen.TestSetMetRegelEnParam)" />

--- a/solutions/ALEF_Testen/models/ALEF_Testen.eenheden@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.eenheden@tests.mps
@@ -7,7 +7,7 @@
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
   </languages>

--- a/solutions/ALEF_Testen/models/ALEF_Testen.testSetDuplicateName@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.testSetDuplicateName@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />

--- a/solutions/ALEF_Testen/models/ALEF_Testen.unittest@tests.mps
+++ b/solutions/ALEF_Testen/models/ALEF_Testen.unittest@tests.mps
@@ -9,7 +9,7 @@
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />

--- a/solutions/Beslistabellen_Test/Beslistabellen_Test.msd
+++ b/solutions/Beslistabellen_Test/Beslistabellen_Test.msd
@@ -68,7 +68,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Beslistabellen_Test/models/Beslistabellen_Test.ALEFS623.mps
+++ b/solutions/Beslistabellen_Test/models/Beslistabellen_Test.ALEFS623.mps
@@ -6,7 +6,7 @@
     <use id="7b05b09e-3ac1-4a27-83e2-e4e1a5f17cf3" name="beslistabelspraak" version="2" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="09c04f52-88c5-4bd6-a481-cabab9f61ff5" name="contexts" version="0" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <devkit ref="d07fa9c5-678d-4a9b-9eaf-b1b8c569b820(alef.devkit)" />
   </languages>
   <imports>

--- a/solutions/Besturingspraak_Test/Besturingspraak_Test.msd
+++ b/solutions/Besturingspraak_Test/Besturingspraak_Test.msd
@@ -61,7 +61,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:643ee156-beaa-484d-abfc-2a8879c50ed2:unittestspraak" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />

--- a/solutions/Concatenatie_Test/Concatenatie_Test.msd
+++ b/solutions/Concatenatie_Test/Concatenatie_Test.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Consistentieregel_Test/Consistentieregel_Test.msd
+++ b/solutions/Consistentieregel_Test/Consistentieregel_Test.msd
@@ -60,7 +60,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Consistentieregel_Test/models/Consistentieregel_Test.Intention@tests.mps
+++ b/solutions/Consistentieregel_Test/models/Consistentieregel_Test.Intention@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="mw3" ref="r:4bce8404-98a6-49ea-9b52-9dfb138ed7f6(Consistentieregel_Test.tests)" />

--- a/solutions/Constructie_Test/Constructie_Test.msd
+++ b/solutions/Constructie_Test/Constructie_Test.msd
@@ -58,7 +58,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Constructie_Test/models/Constructie_Test.RolCheck@tests.mps
+++ b/solutions/Constructie_Test/models/Constructie_Test.RolCheck@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
   </languages>
   <imports>

--- a/solutions/Dimensies_Test/Dimensies_Test.msd
+++ b/solutions/Dimensies_Test/Dimensies_Test.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Editor_Test/Editor_Test.msd
+++ b/solutions/Editor_Test/Editor_Test.msd
@@ -70,7 +70,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Editor_Test/models/Editors.BooleanLiteralEditor@tests.mps
+++ b/solutions/Editor_Test/models/Editors.BooleanLiteralEditor@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />

--- a/solutions/Editor_Test/models/Editors.TelTransformaties@tests.mps
+++ b/solutions/Editor_Test/models/Editors.TelTransformaties@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>

--- a/solutions/Editor_Test/models/Editors.TestEditors@tests.mps
+++ b/solutions/Editor_Test/models/Editors.TestEditors@tests.mps
@@ -4,7 +4,7 @@
   <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="8x8p" ref="r:4f06f137-8875-46b2-95c8-a75b81fd2b97(Editor_Test.definities)" />

--- a/solutions/FeitAfleiding_Test/FeitAfleiding_Test.msd
+++ b/solutions/FeitAfleiding_Test/FeitAfleiding_Test.msd
@@ -59,7 +59,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/GeldigheidsPeriode/GeldigheidsPeriode.msd
+++ b/solutions/GeldigheidsPeriode/GeldigheidsPeriode.msd
@@ -56,7 +56,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/GeldigheidsPeriode/models/tests@tests.mps
+++ b/solutions/GeldigheidsPeriode/models/tests@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="r8sj" ref="r:37b2c05b-ee6c-4434-8fc7-fb146025dd38(GeldigheidsPeriode.specificaties)" />

--- a/solutions/Hergebruik_base/Hergebruik_base.msd
+++ b/solutions/Hergebruik_base/Hergebruik_base.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Hygiene_Test/Hygiene_Test.msd
+++ b/solutions/Hygiene_Test/Hygiene_Test.msd
@@ -44,7 +44,7 @@
     <language slang="l:b2fc4154-1657-4d74-8828-c55b57a96ecd:rapporten" version="2" />
     <language slang="l:7bbaf860-5f96-44b4-9731-6e00ae137ece:regelspraak" version="29" />
     <language slang="l:d8af31be-1847-4d5b-8686-78e232d4e0f8:servicespraak" version="19" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/solutions/Hygiene_Test/models/Hygiene_Test.servicespraak@tests.mps
+++ b/solutions/Hygiene_Test/models/Hygiene_Test.servicespraak@tests.mps
@@ -9,7 +9,7 @@
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="7b05b09e-3ac1-4a27-83e2-e4e1a5f17cf3" name="beslistabelspraak" version="2" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
     <use id="65239ca4-9057-41f8-999d-97fa1a60b298" name="besturingspraak" version="2" />
   </languages>

--- a/solutions/Hygiene_Test/models/Hygiene_Test.testspraak@tests.mps
+++ b/solutions/Hygiene_Test/models/Hygiene_Test.testspraak@tests.mps
@@ -9,7 +9,7 @@
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="7b05b09e-3ac1-4a27-83e2-e4e1a5f17cf3" name="beslistabelspraak" version="2" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="3ic2" ref="r:1be64251-a392-4bb4-8ecb-06d30a9277a4(gegevensspraak.structure)" />

--- a/solutions/Literal_Test/Literal_Test.msd
+++ b/solutions/Literal_Test/Literal_Test.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/MeerdereObjecten_Test/MeerdereObjecten_Test.msd
+++ b/solutions/MeerdereObjecten_Test/MeerdereObjecten_Test.msd
@@ -64,7 +64,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/MeerdereObjecten_Test/models/EenOpMeer_Aggregaat@tests.mps
+++ b/solutions/MeerdereObjecten_Test/models/EenOpMeer_Aggregaat@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>

--- a/solutions/MeerdereObjecten_Test/models/EenOpMeer_Gelijkstelling@tests.mps
+++ b/solutions/MeerdereObjecten_Test/models/EenOpMeer_Gelijkstelling@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
   </languages>
   <imports>

--- a/solutions/ModelChecks_Test/ModelChecks_Test.msd
+++ b/solutions/ModelChecks_Test/ModelChecks_Test.msd
@@ -67,7 +67,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/ModelChecks_Test/models/ModelChecks_Test.checks@tests.mps
+++ b/solutions/ModelChecks_Test/models/ModelChecks_Test.checks@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="65239ca4-9057-41f8-999d-97fa1a60b298" name="besturingspraak" version="2" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />

--- a/solutions/ObjExtensies/ObjExtensies.msd
+++ b/solutions/ObjExtensies/ObjExtensies.msd
@@ -58,7 +58,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Onderwerpen_Test/Onderwerpen_Test.msd
+++ b/solutions/Onderwerpen_Test/Onderwerpen_Test.msd
@@ -63,7 +63,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/OpenApiGenerator_Test/OpenApiGenerator_Test.msd
+++ b/solutions/OpenApiGenerator_Test/OpenApiGenerator_Test.msd
@@ -70,7 +70,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Rapportage/Rapportage_Test.msd
+++ b/solutions/Rapportage/Rapportage_Test.msd
@@ -70,7 +70,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Rapportage_Test_External_Module/Rapportage_Test_External_Module.msd
+++ b/solutions/Rapportage_Test_External_Module/Rapportage_Test_External_Module.msd
@@ -56,7 +56,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/RegelCondities_Test/RegelCondities_Test.msd
+++ b/solutions/RegelCondities_Test/RegelCondities_Test.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/RekenenMetDatumTijd_Test/RekenenMetDatumTijd_Test.msd
+++ b/solutions/RekenenMetDatumTijd_Test/RekenenMetDatumTijd_Test.msd
@@ -66,7 +66,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:643ee156-beaa-484d-abfc-2a8879c50ed2:unittestspraak" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />

--- a/solutions/RekenenMetDatumTijd_Test/models/RekenenMetDatumTijd_Test.Tijdsgranulariteiten@tests.mps
+++ b/solutions/RekenenMetDatumTijd_Test/models/RekenenMetDatumTijd_Test.Tijdsgranulariteiten@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="c40e126b-a0e9-42bb-b903-9b5fd0b050d2" name="gegevensspraak.tijd" version="4" />
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />

--- a/solutions/RekenenMetDatumTijd_Test/models/Unittest@tests.mps
+++ b/solutions/RekenenMetDatumTijd_Test/models/Unittest@tests.mps
@@ -7,7 +7,7 @@
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="r2nh" ref="r:05a8f765-7ff1-45ab-8d9d-4557ba983db4(regelspraak.typesystem)" />

--- a/solutions/RekenkundigeFuncties_Test/RekenkundigeFuncties_Test.msd
+++ b/solutions/RekenkundigeFuncties_Test/RekenkundigeFuncties_Test.msd
@@ -66,7 +66,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:bef79dc4-9060-4318-a10a-46eb2fa0f3b1:translator" version="1" />
     <language slang="l:643ee156-beaa-484d-abfc-2a8879c50ed2:unittestspraak" version="0" />

--- a/solutions/RekenkundigeFuncties_Test/models/RekenkundigeFuncties_Test.Unittests@tests.mps
+++ b/solutions/RekenkundigeFuncties_Test/models/RekenkundigeFuncties_Test.Unittests@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />

--- a/solutions/Servicespraak_Test/Servicespraak_Test.msd
+++ b/solutions/Servicespraak_Test/Servicespraak_Test.msd
@@ -68,7 +68,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Solver_Test/Solver_Test.msd
+++ b/solutions/Solver_Test/Solver_Test.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Test_Spraken/Test_Spraken.msd
+++ b/solutions/Test_Spraken/Test_Spraken.msd
@@ -67,7 +67,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:643ee156-beaa-484d-abfc-2a8879c50ed2:unittestspraak" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />

--- a/solutions/Test_Spraken/models/Test_Spraken.ALEFS763@tests.mps
+++ b/solutions/Test_Spraken/models/Test_Spraken.ALEFS763@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
   </languages>

--- a/solutions/Test_Spraken/models/Test_Spraken.TestInvoer@tests.mps
+++ b/solutions/Test_Spraken/models/Test_Spraken.TestInvoer@tests.mps
@@ -4,7 +4,7 @@
   <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />

--- a/solutions/Test_Spraken/models/Test_Spraken.TestgevalEnkelvoudigeRol@tests.mps
+++ b/solutions/Test_Spraken/models/Test_Spraken.TestgevalEnkelvoudigeRol@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>

--- a/solutions/Testspraak_Test/Testspraak_Test.msd
+++ b/solutions/Testspraak_Test/Testspraak_Test.msd
@@ -66,7 +66,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:bef79dc4-9060-4318-a10a-46eb2fa0f3b1:translator" version="1" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />

--- a/solutions/Testspraak_Test/models/choice@tests.mps
+++ b/solutions/Testspraak_Test/models/choice@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
   </languages>

--- a/solutions/Testspraak_Test/models/datatypen@tests.mps
+++ b/solutions/Testspraak_Test/models/datatypen@tests.mps
@@ -6,7 +6,7 @@
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="08d6f877-03cc-45d3-b03c-d6f786266853" name="bronspraak" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
   </languages>
   <imports>

--- a/solutions/Testspraak_Test/models/parameters@tests.mps
+++ b/solutions/Testspraak_Test/models/parameters@tests.mps
@@ -5,7 +5,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="e34l" ref="r:94d270b1-8343-4f2a-8da8-39fe36614530(Testspraak_Test.servicetest2testset.parameters)" />

--- a/solutions/Testspraak_Test/models/servicetestconversie@tests.mps
+++ b/solutions/Testspraak_Test/models/servicetestconversie@tests.mps
@@ -5,7 +5,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="3fcf" ref="r:2d073f50-2de2-4e7c-9931-a36ecfe03f2d(Testspraak_Test.servicetest2testset.servicetestconversie)" />

--- a/solutions/Testspraak_Test/models/servicetestid@tests.mps
+++ b/solutions/Testspraak_Test/models/servicetestid@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />

--- a/solutions/Testspraak_Test/models/servicetesttrees@tests.mps
+++ b/solutions/Testspraak_Test/models/servicetesttrees@tests.mps
@@ -6,7 +6,7 @@
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="mkww" ref="r:b66c2e08-dfa1-46c6-8fb5-c6d940243d77(Testspraak_Test.servicetest2testset.servicetesttrees)" />

--- a/solutions/Testspraak_Test/models/tijd@tests.mps
+++ b/solutions/Testspraak_Test/models/tijd@tests.mps
@@ -5,7 +5,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="bef79dc4-9060-4318-a10a-46eb2fa0f3b1" name="translator" version="1" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
   </languages>

--- a/solutions/TypeSystem_Test/TypeSystem_Test.msd
+++ b/solutions/TypeSystem_Test/TypeSystem_Test.msd
@@ -65,7 +65,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Uniciteit_Test/Uniciteit_Test.msd
+++ b/solutions/Uniciteit_Test/Uniciteit_Test.msd
@@ -60,7 +60,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Variabelen_Test/Variabelen_Test.msd
+++ b/solutions/Variabelen_Test/Variabelen_Test.msd
@@ -62,7 +62,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Vrijspraak_Test/Vrijspraak_Test.msd
+++ b/solutions/Vrijspraak_Test/Vrijspraak_Test.msd
@@ -64,7 +64,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/Werkwoorden/Werkwoorden.msd
+++ b/solutions/Werkwoorden/Werkwoorden.msd
@@ -55,7 +55,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/alef.template/alef.template.msd
+++ b/solutions/alef.template/alef.template.msd
@@ -56,7 +56,7 @@
     <language slang="l:b2fc4154-1657-4d74-8828-c55b57a96ecd:rapporten" version="2" />
     <language slang="l:7bbaf860-5f96-44b4-9731-6e00ae137ece:regelspraak" version="29" />
     <language slang="l:d8af31be-1847-4d5b-8686-78e232d4e0f8:servicespraak" version="19" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/solutions/alef.template/models/alef.template.project.mps
+++ b/solutions/alef.template/models/alef.template.project.mps
@@ -15,7 +15,7 @@
     <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="1" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
   </languages>
   <imports>

--- a/solutions/ide_Test/ide_Test.msd
+++ b/solutions/ide_Test/ide_Test.msd
@@ -66,7 +66,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Bronspraak/Bronspraak.msd
+++ b/solutions/test/Bronspraak/Bronspraak.msd
@@ -59,7 +59,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Gegevensspraak/Gegevensspraak.msd
+++ b/solutions/test/Gegevensspraak/Gegevensspraak.msd
@@ -63,7 +63,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Regelspraak/Regelspraak.msd
+++ b/solutions/test/Regelspraak/Regelspraak.msd
@@ -68,7 +68,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Servicespraak/Servicespraak.msd
+++ b/solutions/test/Servicespraak/Servicespraak.msd
@@ -69,7 +69,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Servicespraak/models/IdentificerendBerichtVeld@tests.mps
+++ b/solutions/test/Servicespraak/models/IdentificerendBerichtVeld@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="65239ca4-9057-41f8-999d-97fa1a60b298" name="besturingspraak" version="2" />
   </languages>
   <imports>

--- a/solutions/test/Servicespraak/models/Invoer@tests.mps
+++ b/solutions/test/Servicespraak/models/Invoer@tests.mps
@@ -5,7 +5,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="65239ca4-9057-41f8-999d-97fa1a60b298" name="besturingspraak" version="2" />

--- a/solutions/test/Servicespraak/models/legeVoorspelling@tests.mps
+++ b/solutions/test/Servicespraak/models/legeVoorspelling@tests.mps
@@ -7,7 +7,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="65239ca4-9057-41f8-999d-97fa1a60b298" name="besturingspraak" version="2" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
   </languages>

--- a/solutions/test/Testspraak/Testspraak.msd
+++ b/solutions/test/Testspraak/Testspraak.msd
@@ -75,7 +75,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Testspraak/models/ImportServiceBerichtAlsServiceTest@tests.mps
+++ b/solutions/test/Testspraak/models/ImportServiceBerichtAlsServiceTest@tests.mps
@@ -9,7 +9,7 @@
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="d65f6f0b-d425-4cdb-985f-4194ffdf3ab2" name="json" version="0" />
   </languages>
   <imports>

--- a/solutions/test/Testspraak/models/modelchecks@tests.mps
+++ b/solutions/test/Testspraak/models/modelchecks@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="6ldf" ref="r:c5746a0f-657b-4fe9-854e-d6f7344868a2(testspraak.structure)" />

--- a/solutions/test/Testspraak/models/servicetest.ALEFS420@tests.mps
+++ b/solutions/test/Testspraak/models/servicetest.ALEFS420@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="2wws" ref="r:4fe1ef6d-69d5-49c6-ad27-dafb26f9234c(servicetest.ALEFS420)" />

--- a/solutions/test/Testspraak/models/servicetest.choice@tests.mps
+++ b/solutions/test/Testspraak/models/servicetest.choice@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
   </languages>
   <imports>

--- a/solutions/test/Testspraak/models/testbericht.HerhalendGeordendBerichttype@tests.mps
+++ b/solutions/test/Testspraak/models/testbericht.HerhalendGeordendBerichttype@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="22i3" ref="r:40ca1e86-75d9-434a-bf23-f5d88735933f(testbericht.HerhalendGeordendBerichttype)" />

--- a/solutions/test/Tijdspraak/Tijdspraak.msd
+++ b/solutions/test/Tijdspraak/Tijdspraak.msd
@@ -85,7 +85,7 @@
     <language slang="l:dd4c0bf2-9ffb-4d92-ab71-559516bb542f:servicetestNaarXml" version="0" />
     <language slang="l:6494aba8-a154-4ad7-9bae-973ee96ec409:servicetestNaarXml.tijd" version="0" />
     <language slang="l:f1fde5ac-c94f-4400-a54e-227925768f25:testNaarUnittest" version="0" />
-    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="23" />
+    <language slang="l:8bc962c0-cb3c-49f0-aa03-23c3bc0304b0:testspraak" version="24" />
     <language slang="l:75b1dcc9-4d65-4537-bd22-03b6cf247f5f:testspraak.tijd" version="0" />
     <language slang="l:4f7705db-6cde-4dd2-bae3-c8d8801d8324:vrijspraak" version="0" />
     <language slang="l:51f8c68a-90ac-4dbf-b58a-c9e9db784c81:xml.schema" version="0" />

--- a/solutions/test/Tijdspraak/models/ALEFS442@tests.mps
+++ b/solutions/test/Tijdspraak/models/ALEFS442@tests.mps
@@ -7,7 +7,7 @@
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="c40e126b-a0e9-42bb-b903-9b5fd0b050d2" name="gegevensspraak.tijd" version="4" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />

--- a/solutions/test/Tijdspraak/models/Tijd_Aggregaties@tests.mps
+++ b/solutions/test/Tijdspraak/models/Tijd_Aggregaties@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
   </languages>

--- a/solutions/test/Tijdspraak/models/Tijd_Onderwerp.mps
+++ b/solutions/test/Tijdspraak/models/Tijd_Onderwerp.mps
@@ -7,7 +7,7 @@
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="c40e126b-a0e9-42bb-b903-9b5fd0b050d2" name="gegevensspraak.tijd" version="4" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <devkit ref="d07fa9c5-678d-4a9b-9eaf-b1b8c569b820(alef.devkit)" />
   </languages>
   <imports>

--- a/solutions/test/Tijdspraak/models/Tijd_Service@tests.mps
+++ b/solutions/test/Tijdspraak/models/Tijd_Service@tests.mps
@@ -6,7 +6,7 @@
     <use id="d8af31be-1847-4d5b-8686-78e232d4e0f8" name="servicespraak" version="19" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
     <use id="26c003b8-2642-44b1-8d28-63f478da851b" name="servicespraak.tijd" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="argw" ref="r:8c4b3f34-22fb-4c55-972c-ae53ff6bf2a2(Tijd_Service)" />

--- a/solutions/test/Tijdspraak/models/Tijd_Testspraak.importServiceBerichtAlsServiceTest@tests.mps
+++ b/solutions/test/Tijdspraak/models/Tijd_Testspraak.importServiceBerichtAlsServiceTest@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
     <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="0" />
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />

--- a/solutions/test/Tijdspraak/models/initialisatie@tests.mps
+++ b/solutions/test/Tijdspraak/models/initialisatie@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="c40e126b-a0e9-42bb-b903-9b5fd0b050d2" name="gegevensspraak.tijd" version="4" />
   </languages>

--- a/solutions/test/Tijdspraak/models/intentions@tests.mps
+++ b/solutions/test/Tijdspraak/models/intentions@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="c40e126b-a0e9-42bb-b903-9b5fd0b050d2" name="gegevensspraak.tijd" version="4" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />

--- a/solutions/test/Tijdspraak/models/linguistics@tests.mps
+++ b/solutions/test/Tijdspraak/models/linguistics@tests.mps
@@ -12,7 +12,7 @@
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="7b05b09e-3ac1-4a27-83e2-e4e1a5f17cf3" name="beslistabelspraak" version="2" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="nksh" ref="r:a26329d1-d16f-4b93-aa0b-bf7b01d59c38(regelspraak.tijd.typesystem)" />

--- a/solutions/test/Tijdspraak/models/meervoudigeToekenningen@tests.mps
+++ b/solutions/test/Tijdspraak/models/meervoudigeToekenningen@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="29" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="c40e126b-a0e9-42bb-b903-9b5fd0b050d2" name="gegevensspraak.tijd" version="4" />
     <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
     <use id="09c04f52-88c5-4bd6-a481-cabab9f61ff5" name="contexts" version="0" />

--- a/solutions/test/Tijdspraak/models/modelchecks@tests.mps
+++ b/solutions/test/Tijdspraak/models/modelchecks@tests.mps
@@ -13,7 +13,7 @@
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="7b05b09e-3ac1-4a27-83e2-e4e1a5f17cf3" name="beslistabelspraak" version="2" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="nksh" ref="r:a26329d1-d16f-4b93-aa0b-bf7b01d59c38(regelspraak.tijd.typesystem)" />

--- a/solutions/test/Tijdspraak/models/totaal@tests.mps
+++ b/solutions/test/Tijdspraak/models/totaal@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />
   </languages>
   <imports>

--- a/solutions/test/Tijdspraak/models/typechecker@tests.mps
+++ b/solutions/test/Tijdspraak/models/typechecker@tests.mps
@@ -10,7 +10,7 @@
     <use id="299845ab-8a41-470d-b76f-9736f9b49925" name="regelspraak.tijd" version="7" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="75b1dcc9-4d65-4537-bd22-03b6cf247f5f" name="testspraak.tijd" version="0" />
-    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="23" />
+    <use id="8bc962c0-cb3c-49f0-aa03-23c3bc0304b0" name="testspraak" version="24" />
   </languages>
   <imports>
     <import index="kv3i" ref="r:56466842-ffd5-43f7-9586-cb6fa442aeb4(regelspraak.tijd.translator)" />


### PR DESCRIPTION
References to the same rule set in test sets, caused by the migration to ALEF 14.2.0, will be deduplicated automatically.