### PR TITLE
Make class-names more unique

### DIFF
--- a/languages/merlinBuild/models/merlinBuild.behavior.mps
+++ b/languages/merlinBuild/models/merlinBuild.behavior.mps
@@ -328,11 +328,11 @@
     <node concept="2YIFZL" id="3s5saVVNIMA" role="jymVt">
       <property role="TrG5h" value="mavenArtifactId" />
       <node concept="3clFbS" id="3s5saVVNIMD" role="3clF47">
-        <node concept="3clFbF" id="L78gu4JDVb" role="3cqZAp">
-          <node concept="2YIFZM" id="L78gu55s_f" role="3clFbG">
-            <ref role="37wK5l" to="wvoc:L78gu554MS" resolve="unqiueJavaFilename" />
-            <ref role="1Pybhc" to="wvoc:7PqDgR_DS2Y" resolve="JavaUtil" />
-            <node concept="2OqwBi" id="L78gu55s_g" role="37wK5m">
+        <node concept="3cpWs8" id="7SZWWc_mgVz" role="3cqZAp">
+          <node concept="3cpWsn" id="7SZWWc_mgV5" role="3cpWs9">
+            <property role="TrG5h" value="prefix" />
+            <node concept="17QB3L" id="7SZWWc_mgVy" role="1tU5fm" />
+            <node concept="2OqwBi" id="L78gu55s_g" role="33vP2m">
               <node concept="2OqwBi" id="L78gu55s_h" role="2Oq$k0">
                 <node concept="37vLTw" id="L78gu55s_i" role="2Oq$k0">
                   <ref role="3cqZAo" node="3s5saVVNJYu" resolve="node" />
@@ -343,8 +343,22 @@
                 <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
               </node>
             </node>
-            <node concept="37vLTw" id="L78gu55s_l" role="37wK5m">
-              <ref role="3cqZAo" node="3s5saVVNJYu" resolve="node" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="L78gu4JDVb" role="3cqZAp">
+          <node concept="2YIFZM" id="7SZWWc_mjnn" role="3clFbG">
+            <ref role="1Pybhc" to="wvoc:7PqDgR_DS2Y" resolve="JavaUtil" />
+            <ref role="37wK5l" to="wvoc:3qwAmpfs6JS" resolve="asJavaFilename" />
+            <node concept="37vLTw" id="7SZWWc_mjno" role="37wK5m">
+              <ref role="3cqZAo" node="7SZWWc_mgV5" resolve="prefix" />
+            </node>
+            <node concept="2OqwBi" id="7SZWWc_mjnp" role="37wK5m">
+              <node concept="37vLTw" id="7SZWWc_mjnq" role="2Oq$k0">
+                <ref role="3cqZAo" node="3s5saVVNJYu" resolve="node" />
+              </node>
+              <node concept="3TrcHB" id="7SZWWc_mjnr" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
             </node>
           </node>
         </node>

--- a/languages/objecten/languageModels/utils.mps
+++ b/languages/objecten/languageModels/utils.mps
@@ -663,7 +663,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="7e8iM688JAC" role="jymVt" />
     <node concept="2YIFZL" id="2p$06uIxzTN" role="jymVt">
       <property role="TrG5h" value="asJavaPrefixMethod" />
       <property role="od$2w" value="false" />
@@ -773,19 +772,19 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7grPb70tWl7" role="3clF47">
-        <node concept="3clFbF" id="7grPb70tWl8" role="3cqZAp">
-          <node concept="2OqwBi" id="7grPb70tWl9" role="3clFbG">
-            <node concept="37vLTw" id="7grPb70tWla" role="2Oq$k0">
+        <node concept="3clFbF" id="7SZWWc$fe6q" role="3cqZAp">
+          <node concept="2OqwBi" id="7SZWWc$e$B2" role="3clFbG">
+            <node concept="37vLTw" id="7SZWWc$e$B3" role="2Oq$k0">
               <ref role="3cqZAo" node="7grPb70tWll" resolve="genContext" />
             </node>
-            <node concept="2piZGk" id="7grPb70tWlb" role="2OqNvi">
-              <node concept="2YIFZM" id="7grPb70tWlc" role="2piZGb">
+            <node concept="2piZGk" id="7SZWWc$e$B4" role="2OqNvi">
+              <node concept="2YIFZM" id="7SZWWc$e$B5" role="2piZGb">
                 <ref role="1Pybhc" node="7PqDgR_DS2Y" resolve="JavaUtil" />
                 <ref role="37wK5l" node="3qwAmpfs6JS" resolve="asJavaFilename" />
-                <node concept="37vLTw" id="7grPb70tWld" role="37wK5m">
+                <node concept="37vLTw" id="7SZWWc$e$B6" role="37wK5m">
                   <ref role="3cqZAo" node="7grPb70tWlj" resolve="prefix" />
                 </node>
-                <node concept="37vLTw" id="7grPb70tY55" role="37wK5m">
+                <node concept="37vLTw" id="7SZWWc$e$B7" role="37wK5m">
                   <ref role="3cqZAo" node="7grPb70tWln" resolve="name" />
                 </node>
               </node>
@@ -811,6 +810,7 @@
         <node concept="17QB3L" id="7grPb70tXv9" role="1tU5fm" />
       </node>
     </node>
+    <node concept="2tJIrI" id="7SZWWc$Xy9N" role="jymVt" />
     <node concept="2YIFZL" id="rblCqm3KON" role="jymVt">
       <property role="TrG5h" value="asJavaClassNameWithRoot" />
       <node concept="3clFbS" id="rblCqm3KOQ" role="3clF47">
@@ -1048,7 +1048,7 @@
     <node concept="2tJIrI" id="3qwAmpfs9Xq" role="jymVt" />
     <node concept="2YIFZL" id="3qwAmpfs6JS" role="jymVt">
       <property role="TrG5h" value="asJavaFilename" />
-      <node concept="3Tm6S6" id="3qwAmpfs6JT" role="1B3o_S" />
+      <node concept="3Tm1VV" id="7SZWWc_mfxX" role="1B3o_S" />
       <node concept="17QB3L" id="3qwAmpfs6JU" role="3clF45" />
       <node concept="37vLTG" id="3qwAmpfs6JL" role="3clF46">
         <property role="TrG5h" value="prefix" />
@@ -1087,104 +1087,55 @@
           </node>
         </node>
         <node concept="3cpWs6" id="3qwAmpfs6J$" role="3cqZAp">
-          <node concept="3cpWs3" id="3qwAmpfs6J_" role="3cqZAk">
-            <node concept="3cpWs3" id="3qwAmpfs6JA" role="3uHU7B">
-              <node concept="37vLTw" id="3qwAmpfs6JP" role="3uHU7B">
-                <ref role="3cqZAo" node="3qwAmpfs6JL" resolve="prefix" />
-              </node>
-              <node concept="1Xhbcc" id="3qwAmpfs6JC" role="3uHU7w">
-                <property role="1XhdNS" value="_" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="3qwAmpfv8hg" role="3uHU7w">
-              <node concept="37vLTw" id="3qwAmpfv8hh" role="2Oq$k0">
-                <ref role="3cqZAo" node="3qwAmpfv8fS" resolve="valid" />
-              </node>
-              <node concept="liA8E" id="3qwAmpfv8hi" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
-                <node concept="3cmrfG" id="3qwAmpfv8hj" role="37wK5m">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="2YIFZM" id="3qwAmpfv8hk" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Math.min(int,int)" resolve="min" />
-                  <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                  <node concept="3cmrfG" id="3qwAmpfvbTi" role="37wK5m">
-                    <property role="3cmrfH" value="30" />
-                  </node>
-                  <node concept="2OqwBi" id="3qwAmpfv8hm" role="37wK5m">
-                    <node concept="37vLTw" id="3qwAmpfv8hn" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3qwAmpfv8fS" resolve="valid" />
-                    </node>
-                    <node concept="liA8E" id="3qwAmpfv8ho" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="L78gu557pq" role="jymVt" />
-    <node concept="2YIFZL" id="L78gu554MS" role="jymVt">
-      <property role="TrG5h" value="unqiueJavaFilename" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="3clFbS" id="L78gu554MT" role="3clF47">
-        <node concept="3cpWs8" id="L78gu55e3F" role="3cqZAp">
-          <node concept="3cpWsn" id="L78gu55e3G" role="3cpWs9">
-            <property role="TrG5h" value="name" />
-            <property role="3TUv4t" value="true" />
-            <node concept="17QB3L" id="L78gu55dtW" role="1tU5fm" />
-            <node concept="2OqwBi" id="L78gu55e3H" role="33vP2m">
-              <node concept="37vLTw" id="L78gu55e3I" role="2Oq$k0">
-                <ref role="3cqZAo" node="L78gu554Ng" resolve="node" />
-              </node>
-              <node concept="3TrcHB" id="L78gu55e3J" role="2OqNvi">
-                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="L78gu55b$P" role="3cqZAp">
-          <node concept="3cpWs3" id="L78gu55jUR" role="3clFbG">
-            <node concept="3cpWs3" id="L78gu55dhk" role="3uHU7B">
-              <node concept="1rXfSq" id="3qwAmpfsbNv" role="3uHU7B">
-                <ref role="37wK5l" node="3qwAmpfs6JS" resolve="asJavaFilename" />
-                <node concept="37vLTw" id="3qwAmpfsczB" role="37wK5m">
-                  <ref role="3cqZAo" node="L78gu554Nc" resolve="prefix" />
-                </node>
-                <node concept="37vLTw" id="3qwAmpfsdhE" role="37wK5m">
-                  <ref role="3cqZAo" node="L78gu55e3G" resolve="name" />
-                </node>
-              </node>
-              <node concept="1Xhbcc" id="L78gu55l6P" role="3uHU7w">
-                <property role="1XhdNS" value="_" />
-              </node>
-            </node>
-            <node concept="1rXfSq" id="2zInMj6jSY7" role="3uHU7w">
+          <node concept="3cpWs3" id="7SZWWc_m4Qg" role="3cqZAk">
+            <node concept="1rXfSq" id="7SZWWc_m5Vm" role="3uHU7w">
               <ref role="37wK5l" node="2zInMj6juDy" resolve="md5Hex" />
-              <node concept="37vLTw" id="2zInMj6jTuP" role="37wK5m">
-                <ref role="3cqZAo" node="L78gu55e3G" resolve="name" />
+              <node concept="37vLTw" id="7SZWWc_m7xY" role="37wK5m">
+                <ref role="3cqZAo" node="3qwAmpfs6JN" resolve="name" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="7SZWWc_lX4o" role="3uHU7B">
+              <node concept="3cpWs3" id="3qwAmpfs6J_" role="3uHU7B">
+                <node concept="3cpWs3" id="3qwAmpfs6JA" role="3uHU7B">
+                  <node concept="37vLTw" id="3qwAmpfs6JP" role="3uHU7B">
+                    <ref role="3cqZAo" node="3qwAmpfs6JL" resolve="prefix" />
+                  </node>
+                  <node concept="1Xhbcc" id="3qwAmpfs6JC" role="3uHU7w">
+                    <property role="1XhdNS" value="_" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="3qwAmpfv8hg" role="3uHU7w">
+                  <node concept="37vLTw" id="3qwAmpfv8hh" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3qwAmpfv8fS" resolve="valid" />
+                  </node>
+                  <node concept="liA8E" id="3qwAmpfv8hi" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                    <node concept="3cmrfG" id="3qwAmpfv8hj" role="37wK5m">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="2YIFZM" id="3qwAmpfv8hk" role="37wK5m">
+                      <ref role="37wK5l" to="wyt6:~Math.min(int,int)" resolve="min" />
+                      <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                      <node concept="3cmrfG" id="3qwAmpfvbTi" role="37wK5m">
+                        <property role="3cmrfH" value="20" />
+                      </node>
+                      <node concept="2OqwBi" id="3qwAmpfv8hm" role="37wK5m">
+                        <node concept="37vLTw" id="3qwAmpfv8hn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3qwAmpfv8fS" resolve="valid" />
+                        </node>
+                        <node concept="liA8E" id="3qwAmpfv8ho" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1Xhbcc" id="7SZWWc_lZO6" role="3uHU7w">
+                <property role="1XhdNS" value="_" />
               </node>
             </node>
           </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="L78gu554Na" role="1B3o_S" />
-      <node concept="17QB3L" id="L78gu554Nb" role="3clF45" />
-      <node concept="37vLTG" id="L78gu554Nc" role="3clF46">
-        <property role="3TUv4t" value="true" />
-        <property role="TrG5h" value="prefix" />
-        <node concept="17QB3L" id="L78gu554Nd" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="L78gu554Ng" role="3clF46">
-        <property role="TrG5h" value="node" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tqbb2" id="L78gu554Nh" role="1tU5fm">
-          <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
The generated Java class/file names were not unique enough causing Java compilation issues for projects with many similar names for rulesets in different models and/or solutions, especially when the filesystem is case insensitive.