### PR TITLE
#71: Prevent (illegal) changes to original nodes when desugaring decision tables

### DIFF
--- a/languages/beslistabelspraak/models/beslistabelspraak.translator.mps
+++ b/languages/beslistabelspraak/models/beslistabelspraak.translator.mps
@@ -276,9 +276,7 @@
       <concept id="6286567188355374159" name="translator.structure.MappingCall" flags="ng" index="21Gwf3">
         <reference id="4200278814376033324" name="field" index="3qchXZ" />
       </concept>
-      <concept id="6286567188355172949" name="translator.structure.Mapping" flags="ig" index="21HLnp">
-        <child id="3847194510283163898" name="guard" index="y8jfW" />
-      </concept>
+      <concept id="6286567188355172949" name="translator.structure.Mapping" flags="ig" index="21HLnp" />
       <concept id="6286567188355172292" name="translator.structure.Translator" flags="ig" index="21HLx8" />
       <concept id="1282916365056958487" name="translator.structure.TranslatorCallOperation" flags="ng" index="m3bmO">
         <child id="1282916365056958490" name="call" index="m3bmT" />
@@ -293,9 +291,6 @@
         <reference id="6061541770080895228" name="superTranslator" index="28KUNz" />
       </concept>
       <concept id="6444515760302816786" name="translator.structure.thisMapping" flags="ng" index="3rbJFy" />
-      <concept id="8039584331503908420" name="translator.structure.Guard" flags="ng" index="3Mx64u">
-        <child id="8039584331503908421" name="condition" index="3Mx64v" />
-      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -2802,6 +2797,10 @@
     <property role="TrG5h" value="BeslistabelDesugaring" />
     <property role="3GE5qa" value="desugar" />
     <node concept="21FBqJ" id="6GK5Pk246Kb" role="jymVt" />
+    <node concept="21FBr8" id="70BIiIgzvUF" role="jymVt">
+      <property role="21FBra" value="Also used in read-only contexts; make sure not to change the originals!" />
+    </node>
+    <node concept="21FBqJ" id="70BIiIgzobq" role="jymVt" />
     <node concept="21HLnp" id="6AXKzO7xxoZ" role="jymVt">
       <property role="1EzhhJ" value="true" />
       <node concept="37vLTG" id="6AXKzO7xxp0" role="3clF46">
@@ -2825,42 +2824,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="6GK5Pk246T8" role="3clF47">
-        <node concept="3clFbF" id="6R4UUObXHCW" role="3cqZAp">
-          <node concept="2OqwBi" id="6R4UUObXYNS" role="3clFbG">
-            <node concept="2OqwBi" id="6R4UUObXLyw" role="2Oq$k0">
-              <node concept="37vLTw" id="6R4UUObXHCU" role="2Oq$k0">
-                <ref role="3cqZAo" node="6GK5Pk246T7" resolve="btVersie" />
-              </node>
-              <node concept="2Rf3mk" id="6R4UUObXOXP" role="2OqNvi">
-                <node concept="1xMEDy" id="6R4UUObXOXR" role="1xVPHs">
-                  <node concept="chp4Y" id="6R4UUObXSpJ" role="ri$Ld">
-                    <ref role="cht4Q" to="3ic2:v0ioj9PglU" resolve="AbstractNumeriekeLiteral" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2es0OD" id="6R4UUObY8kX" role="2OqNvi">
-              <node concept="1bVj0M" id="6R4UUObY8kZ" role="23t8la">
-                <node concept="3clFbS" id="6R4UUObY8l0" role="1bW5cS">
-                  <node concept="3clFbF" id="6R4UUObYbdY" role="3cqZAp">
-                    <node concept="2OqwBi" id="6R4UUObYCrX" role="3clFbG">
-                      <node concept="37vLTw" id="6R4UUObY$jU" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5vSJaT$FJQx" resolve="it" />
-                      </node>
-                      <node concept="2qgKlT" id="6R4UUObYHb0" role="2OqNvi">
-                        <ref role="37wK5l" to="8l26:6R4UUObYrF6" resolve="haalEenheidBijProvider" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="gl6BB" id="5vSJaT$FJQx" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="5vSJaT$FJQy" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="6GK5Pk24FD2" role="3cqZAp">
           <node concept="2OqwBi" id="6GK5Pk2DHaK" role="3clFbG">
             <node concept="2OqwBi" id="6GK5Pk25aev" role="2Oq$k0">
@@ -3768,6 +3731,7 @@
         <node concept="3cpWs8" id="7p2tph7vgIl" role="3cqZAp">
           <node concept="3cpWsn" id="7p2tph7vgIm" role="3cpWs9">
             <property role="TrG5h" value="predicaat" />
+            <property role="3TUv4t" value="true" />
             <node concept="3Tqbb2" id="7p2tph7v6sh" role="1tU5fm">
               <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
             </node>
@@ -3806,6 +3770,7 @@
           </node>
           <node concept="3clFbS" id="7p2tph7vCbb" role="Jncv$">
             <node concept="3clFbJ" id="7p2tph7vP6q" role="3cqZAp">
+              <property role="TyiWL" value="true" />
               <node concept="3fqX7Q" id="7p2tph7w3_q" role="3clFbw">
                 <node concept="2OqwBi" id="7p2tph7w3_s" role="3fr31v">
                   <node concept="Jnkvi" id="7p2tph7w3_t" role="2Oq$k0">
@@ -3817,11 +3782,11 @@
                 </node>
               </node>
               <node concept="3clFbS" id="7p2tph7vP6s" role="3clFbx">
-                <node concept="3cpWs6" id="7p2tph7wfUU" role="3cqZAp">
-                  <node concept="21Gwf3" id="7p2tph7wkCg" role="3cqZAk">
-                    <ref role="3qchXZ" node="7p2tph7wawp" resolve="ontken" />
-                    <ref role="37wK5l" node="7p2tph7we60" resolve="abstractMapping_nodePredicaat" />
-                    <node concept="37vLTw" id="7p2tph7wpn_" role="37wK5m">
+                <node concept="3clFbF" id="78cIWvKV6aF" role="3cqZAp">
+                  <node concept="2YIFZM" id="78cIWvL9ilq" role="3clFbG">
+                    <ref role="37wK5l" to="ivtb:78cIWvKlHGH" resolve="negatePredicate" />
+                    <ref role="1Pybhc" to="ivtb:2ycYXNhRmBb" resolve="Negator" />
+                    <node concept="37vLTw" id="78cIWvL9ilr" role="37wK5m">
                       <ref role="3cqZAo" node="7p2tph7vgIm" resolve="predicaat" />
                     </node>
                   </node>
@@ -3843,295 +3808,6 @@
       <node concept="3Tm1VV" id="K2G6VufHL9" role="1B3o_S" />
       <node concept="3Tqbb2" id="K2G6VufYTR" role="3clF45">
         <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-      </node>
-    </node>
-    <node concept="21FBqJ" id="6GK5Pk2n_PN" role="jymVt" />
-    <node concept="3qapGz" id="7p2tph7wawp" role="jymVt">
-      <property role="TrG5h" value="ontken" />
-      <node concept="3uibUv" id="7p2tph7wawq" role="1tU5fm">
-        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-      </node>
-      <node concept="3qLKid" id="7p2tph7wawo" role="3qLKi6">
-        <property role="1sVAO0" value="true" />
-        <node concept="21HLnp" id="7p2tph7we60" role="jymVt">
-          <property role="1EzhhJ" value="true" />
-          <node concept="37vLTG" id="7p2tph7we61" role="3clF46">
-            <property role="TrG5h" value="predicaat" />
-            <node concept="3Tqbb2" id="7p2tph7wekw" role="1tU5fm">
-              <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="7p2tph7we62" role="3clF47" />
-          <node concept="3Tm1VV" id="7p2tph7we63" role="1B3o_S" />
-          <node concept="3Tqbb2" id="7p2tph7weY8" role="3clF45">
-            <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-          </node>
-        </node>
-        <node concept="21HLnp" id="7p2tph7x2Sh" role="jymVt">
-          <node concept="37vLTG" id="7p2tph7x2Si" role="3clF46">
-            <property role="TrG5h" value="ontkenbaar" />
-            <node concept="3Tqbb2" id="7p2tph7x4DH" role="1tU5fm">
-              <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="7p2tph7x2Sj" role="3clF47">
-            <node concept="3cpWs8" id="7p2tph7xkTV" role="3cqZAp">
-              <node concept="3cpWsn" id="7p2tph7xkTW" role="3cpWs9">
-                <property role="TrG5h" value="p" />
-                <node concept="2OqwBi" id="7p2tph7xDoN" role="33vP2m">
-                  <node concept="1PxgMI" id="7p2tph7BGc_" role="2Oq$k0">
-                    <node concept="chp4Y" id="7p2tph7BHGK" role="3oSUPX">
-                      <ref role="cht4Q" to="m234:6E7_KuSgO46" resolve="Ontkenbaar" />
-                    </node>
-                    <node concept="37vLTw" id="7p2tph7xAK2" role="1m5AlR">
-                      <ref role="3cqZAo" node="7p2tph7x2Si" resolve="ontkenbaar" />
-                    </node>
-                  </node>
-                  <node concept="1$rogu" id="7p2tph7xGJA" role="2OqNvi" />
-                </node>
-                <node concept="3Tqbb2" id="7p2tph7xt7A" role="1tU5fm">
-                  <ref role="ehGHo" to="m234:6E7_KuSgO46" resolve="Ontkenbaar" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7p2tph7xemz" role="3cqZAp">
-              <node concept="37vLTI" id="7p2tph7xTXJ" role="3clFbG">
-                <node concept="3fqX7Q" id="7p2tph7y8DH" role="37vLTx">
-                  <node concept="2OqwBi" id="7p2tph7y8DJ" role="3fr31v">
-                    <node concept="37vLTw" id="7p2tph7y8DK" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7p2tph7xkTW" resolve="p" />
-                    </node>
-                    <node concept="3TrcHB" id="7p2tph7y8DL" role="2OqNvi">
-                      <ref role="3TsBF5" to="m234:6E7_KuSgO47" resolve="ontkenning" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="7p2tph7xKk_" role="37vLTJ">
-                  <node concept="37vLTw" id="7p2tph7xkTZ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7p2tph7xkTW" resolve="p" />
-                  </node>
-                  <node concept="3TrcHB" id="7p2tph7xRd5" role="2OqNvi">
-                    <ref role="3TsBF5" to="m234:6E7_KuSgO47" resolve="ontkenning" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="7p2tph7yfr8" role="3cqZAp">
-              <node concept="1PxgMI" id="7p2tph7yqm4" role="3cqZAk">
-                <property role="1BlNFB" value="true" />
-                <node concept="chp4Y" id="7p2tph7ytI4" role="3oSUPX">
-                  <ref role="cht4Q" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-                </node>
-                <node concept="37vLTw" id="7p2tph7yjOF" role="1m5AlR">
-                  <ref role="3cqZAo" node="7p2tph7xkTW" resolve="p" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="7p2tph7x2Sk" role="1B3o_S" />
-          <node concept="3Tqbb2" id="7p2tph7x4Vh" role="3clF45">
-            <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-          </node>
-          <node concept="3Mx64u" id="7p2tph7yyAk" role="y8jfW">
-            <node concept="2OqwBi" id="7p2tph7y$Lh" role="3Mx64v">
-              <node concept="37vLTw" id="7p2tph7y$A2" role="2Oq$k0">
-                <ref role="3cqZAo" node="7p2tph7x2Si" resolve="ontkenbaar" />
-              </node>
-              <node concept="1mIQ4w" id="7p2tph7y_4D" role="2OqNvi">
-                <node concept="chp4Y" id="7p2tph7y_75" role="cj9EA">
-                  <ref role="cht4Q" to="m234:6E7_KuSgO46" resolve="Ontkenbaar" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="21HLnp" id="7p2tph7w$7i" role="jymVt">
-          <node concept="37vLTG" id="7p2tph7w$7j" role="3clF46">
-            <property role="TrG5h" value="isgevuld" />
-            <node concept="3Tqbb2" id="7p2tph7wBsc" role="1tU5fm">
-              <ref role="ehGHo" to="m234:5Q$2yZl7vqX" resolve="IsGevuld" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="7p2tph7w$7k" role="3clF47">
-            <node concept="3clFbF" id="7p2tph7wL1v" role="3cqZAp">
-              <node concept="2pJPEk" id="7p2tph7wL1t" role="3clFbG">
-                <node concept="2pJPED" id="7p2tph7wL1u" role="2pJPEn">
-                  <ref role="2pJxaS" to="m234:5Q$2yZl7uiK" resolve="IsLeeg" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="7p2tph7w$7l" role="1B3o_S" />
-          <node concept="3Tqbb2" id="7p2tph7wBIL" role="3clF45">
-            <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-          </node>
-        </node>
-        <node concept="21HLnp" id="7p2tph7wRwv" role="jymVt">
-          <node concept="37vLTG" id="7p2tph7wRww" role="3clF46">
-            <property role="TrG5h" value="isleeg" />
-            <node concept="3Tqbb2" id="7p2tph7wRwx" role="1tU5fm">
-              <ref role="ehGHo" to="m234:5Q$2yZl7uiK" resolve="IsLeeg" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="7p2tph7wRwy" role="3clF47">
-            <node concept="3clFbF" id="7p2tph7wRwz" role="3cqZAp">
-              <node concept="2pJPEk" id="7p2tph7wRw$" role="3clFbG">
-                <node concept="2pJPED" id="7p2tph7wRw_" role="2pJPEn">
-                  <ref role="2pJxaS" to="m234:5Q$2yZl7vqX" resolve="IsGevuld" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="7p2tph7wRwA" role="1B3o_S" />
-          <node concept="3Tqbb2" id="7p2tph7wRwB" role="3clF45">
-            <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
-          </node>
-        </node>
-        <node concept="21HLnp" id="7p2tph7yKHD" role="jymVt">
-          <node concept="37vLTG" id="7p2tph7yKHE" role="3clF46">
-            <property role="TrG5h" value="verg" />
-            <node concept="3Tqbb2" id="7p2tph7yNfg" role="1tU5fm">
-              <ref role="ehGHo" to="m234:5Q$2yZl7AaL" resolve="Vergelijking" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="7p2tph7yKHF" role="3clF47">
-            <node concept="3cpWs8" id="7p2tph7z6ls" role="3cqZAp">
-              <node concept="3cpWsn" id="7p2tph7z6lt" role="3cpWs9">
-                <property role="TrG5h" value="v" />
-                <node concept="3Tqbb2" id="7p2tph7z49c" role="1tU5fm">
-                  <ref role="ehGHo" to="m234:5Q$2yZl7AaL" resolve="Vergelijking" />
-                </node>
-                <node concept="2OqwBi" id="7p2tph7z6lu" role="33vP2m">
-                  <node concept="37vLTw" id="7p2tph7z6lv" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7p2tph7yKHE" resolve="verg" />
-                  </node>
-                  <node concept="1$rogu" id="7p2tph7z6lw" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7p2tph7yU1b" role="3cqZAp">
-              <node concept="37vLTI" id="7p2tph7zodS" role="3clFbG">
-                <node concept="3X5UdL" id="7p2tph7zr_0" role="37vLTx">
-                  <node concept="3X5Udd" id="7p2tph7zD_B" role="3X5gkp">
-                    <node concept="21nZrQ" id="7p2tph7zD_C" role="3X5Uda">
-                      <ref role="21nZrZ" to="m234:4WetKT2PyVQ" resolve="EQ" />
-                    </node>
-                    <node concept="3X5gDF" id="7p2tph7zHgr" role="3X5gFO">
-                      <node concept="2OqwBi" id="7p2tph7$PfA" role="3X5gDC">
-                        <node concept="1XH99k" id="7p2tph7$IjW" role="2Oq$k0">
-                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                        </node>
-                        <node concept="2ViDtV" id="7p2tph7$SIq" role="2OqNvi">
-                          <ref role="2ViDtZ" to="m234:4WetKT2PyVV" resolve="NE" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3X5Udd" id="7p2tph7zM0l" role="3X5gkp">
-                    <node concept="21nZrQ" id="7p2tph7zM0m" role="3X5Uda">
-                      <ref role="21nZrZ" to="m234:4WetKT2PyVV" resolve="NE" />
-                    </node>
-                    <node concept="3X5gDF" id="7p2tph7zQpd" role="3X5gFO">
-                      <node concept="2OqwBi" id="7p2tph7$W3T" role="3X5gDC">
-                        <node concept="1XH99k" id="7p2tph7$W3U" role="2Oq$k0">
-                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                        </node>
-                        <node concept="2ViDtV" id="7p2tph7$W3V" role="2OqNvi">
-                          <ref role="2ViDtZ" to="m234:4WetKT2PyVQ" resolve="EQ" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3X5Udd" id="7p2tph7zUt8" role="3X5gkp">
-                    <node concept="21nZrQ" id="7p2tph7zUt9" role="3X5Uda">
-                      <ref role="21nZrZ" to="m234:4WetKT2PyVU" resolve="GE" />
-                    </node>
-                    <node concept="3X5gDF" id="7p2tph7$2SX" role="3X5gFO">
-                      <node concept="2OqwBi" id="7p2tph7$Zer" role="3X5gDC">
-                        <node concept="1XH99k" id="7p2tph7$Zes" role="2Oq$k0">
-                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                        </node>
-                        <node concept="2ViDtV" id="7p2tph7$Zet" role="2OqNvi">
-                          <ref role="2ViDtZ" to="m234:4WetKT2PyVR" resolve="LT" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3X5Udd" id="7p2tph7$62F" role="3X5gkp">
-                    <node concept="21nZrQ" id="7p2tph7$62G" role="3X5Uda">
-                      <ref role="21nZrZ" to="m234:4WetKT2PyVT" resolve="GT" />
-                    </node>
-                    <node concept="3X5gDF" id="7p2tph7$blI" role="3X5gFO">
-                      <node concept="2OqwBi" id="7p2tph7_2Dj" role="3X5gDC">
-                        <node concept="1XH99k" id="7p2tph7_2Dk" role="2Oq$k0">
-                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                        </node>
-                        <node concept="2ViDtV" id="7p2tph7_2Dl" role="2OqNvi">
-                          <ref role="2ViDtZ" to="m234:4WetKT2PyVS" resolve="LE" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3X5Udd" id="7p2tph7$g00" role="3X5gkp">
-                    <node concept="21nZrQ" id="7p2tph7$g01" role="3X5Uda">
-                      <ref role="21nZrZ" to="m234:4WetKT2PyVR" resolve="LT" />
-                    </node>
-                    <node concept="3X5gDF" id="7p2tph7$li$" role="3X5gFO">
-                      <node concept="2OqwBi" id="7p2tph7_4uB" role="3X5gDC">
-                        <node concept="1XH99k" id="7p2tph7_4uC" role="2Oq$k0">
-                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                        </node>
-                        <node concept="2ViDtV" id="7p2tph7_4uD" role="2OqNvi">
-                          <ref role="2ViDtZ" to="m234:4WetKT2PyVU" resolve="GE" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3X5Udd" id="7p2tph7$q3q" role="3X5gkp">
-                    <node concept="21nZrQ" id="7p2tph7$q3r" role="3X5Uda">
-                      <ref role="21nZrZ" to="m234:4WetKT2PyVS" resolve="LE" />
-                    </node>
-                    <node concept="3X5gDF" id="7p2tph7$tJa" role="3X5gFO">
-                      <node concept="2OqwBi" id="7p2tph7_9fl" role="3X5gDC">
-                        <node concept="1XH99k" id="7p2tph7_9fm" role="2Oq$k0">
-                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                        </node>
-                        <node concept="2ViDtV" id="7p2tph7_9fn" role="2OqNvi">
-                          <ref role="2ViDtZ" to="m234:4WetKT2PyVT" resolve="GT" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="7p2tph7zytx" role="3X5Ude">
-                    <node concept="37vLTw" id="7p2tph7zu1$" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7p2tph7yKHE" resolve="verg" />
-                    </node>
-                    <node concept="3TrcHB" id="7p2tph7z$P2" role="2OqNvi">
-                      <ref role="3TsBF5" to="m234:5Q$2yZl7ALt" resolve="operator" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="7p2tph7zgHF" role="37vLTJ">
-                  <node concept="37vLTw" id="7p2tph7z6lx" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7p2tph7z6lt" resolve="v" />
-                  </node>
-                  <node concept="3TrcHB" id="7p2tph7zj4D" role="2OqNvi">
-                    <ref role="3TsBF5" to="m234:5Q$2yZl7ALt" resolve="operator" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="7p2tph7$$tc" role="3cqZAp">
-              <node concept="37vLTw" id="7p2tph7$F4t" role="3cqZAk">
-                <ref role="3cqZAo" node="7p2tph7z6lt" resolve="v" />
-              </node>
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="7p2tph7yKHG" role="1B3o_S" />
-          <node concept="3Tqbb2" id="7p2tph7yNuj" role="3clF45">
-            <ref role="ehGHo" to="m234:5Q$2yZl7AaL" resolve="Vergelijking" />
-          </node>
-        </node>
       </node>
     </node>
     <node concept="21FBqJ" id="6GK5Pk2dJih" role="jymVt" />
@@ -5244,6 +4920,42 @@
                       <node concept="37vLTw" id="5Q$2yZscUr8" role="37wK5m">
                         <ref role="3cqZAo" node="5Q$2yZscUr5" resolve="newRefTarget" />
                       </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="70BIiIgtFwD" role="3cqZAp">
+              <node concept="2OqwBi" id="70BIiIgtFwE" role="3clFbG">
+                <node concept="2OqwBi" id="70BIiIgtFwF" role="2Oq$k0">
+                  <node concept="2Rf3mk" id="70BIiIgtFwH" role="2OqNvi">
+                    <node concept="1xMEDy" id="70BIiIgtFwI" role="1xVPHs">
+                      <node concept="chp4Y" id="70BIiIgtFwJ" role="ri$Ld">
+                        <ref role="cht4Q" to="3ic2:v0ioj9PglU" resolve="AbstractNumeriekeLiteral" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="70BIiIgtWOE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5Q$2yZrq3$_" resolve="nieuw" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="70BIiIgtFwK" role="2OqNvi">
+                  <node concept="1bVj0M" id="70BIiIgtFwL" role="23t8la">
+                    <node concept="3clFbS" id="70BIiIgtFwM" role="1bW5cS">
+                      <node concept="3clFbF" id="70BIiIgtFwN" role="3cqZAp">
+                        <node concept="2OqwBi" id="70BIiIgtFwO" role="3clFbG">
+                          <node concept="37vLTw" id="70BIiIgtFwP" role="2Oq$k0">
+                            <ref role="3cqZAo" node="70BIiIgtFwR" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="70BIiIgtFwQ" role="2OqNvi">
+                            <ref role="37wK5l" to="8l26:6R4UUObYrF6" resolve="haalEenheidBijProvider" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="70BIiIgtFwR" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="70BIiIgtFwS" role="1tU5fm" />
                     </node>
                   </node>
                 </node>
@@ -13997,32 +13709,6 @@
       </node>
       <node concept="3Tm1VV" id="7sYf6NbV599" role="1B3o_S" />
     </node>
-    <node concept="2tJIrI" id="7sYf6Nc8XVQ" role="jymVt" />
-    <node concept="2YIFZL" id="7sYf6Nc9aoa" role="jymVt">
-      <property role="TrG5h" value="negate" />
-      <node concept="3clFbS" id="7sYf6Nc9aob" role="3clF47">
-        <node concept="3clFbF" id="7sYf6Nc9aoc" role="3cqZAp">
-          <node concept="2YIFZM" id="7sYf6Nc9aod" role="3clFbG">
-            <ref role="37wK5l" to="ivtb:2ycYXNhSb$u" resolve="negate" />
-            <ref role="1Pybhc" to="ivtb:2ycYXNhRmBb" resolve="Negator" />
-            <node concept="37vLTw" id="7sYf6Nc9aoe" role="37wK5m">
-              <ref role="3cqZAo" node="7sYf6Nc9aoh" resolve="conditie" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="7sYf6Nc9jJ_" role="1B3o_S" />
-      <node concept="3Tqbb2" id="7sYf6Nc9aog" role="3clF45">
-        <ref role="ehGHo" to="m234:1ibElXOlZJv" resolve="Conditie" />
-      </node>
-      <node concept="37vLTG" id="7sYf6Nc9aoh" role="3clF46">
-        <property role="TrG5h" value="conditie" />
-        <node concept="3Tqbb2" id="7sYf6Nc9aoi" role="1tU5fm">
-          <ref role="ehGHo" to="m234:1ibElXOlZJv" resolve="Conditie" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7sYf6Nc91P7" role="jymVt" />
     <node concept="2tJIrI" id="7sYf6NbUZL9" role="jymVt" />
     <node concept="2YIFZL" id="7sYf6NbUZLa" role="jymVt">
       <property role="TrG5h" value="samengesteldeVoorwaarde" />
@@ -14777,14 +14463,14 @@
               <node concept="9aQIb" id="7sYf6NceYFI" role="9aQIa">
                 <node concept="3clFbS" id="7sYf6NceYFJ" role="9aQI4">
                   <node concept="3cpWs6" id="7sYf6NceYFK" role="3cqZAp">
-                    <node concept="2YIFZM" id="7sYf6NceYFL" role="3cqZAk">
-                      <ref role="37wK5l" node="7sYf6Nc9aoa" resolve="negate" />
-                      <ref role="1Pybhc" node="7sYf6NbUYcj" resolve="Conditions" />
-                      <node concept="2OqwBi" id="7sYf6NceYFM" role="37wK5m">
-                        <node concept="Jnkvi" id="7sYf6NceYFN" role="2Oq$k0">
+                    <node concept="2YIFZM" id="78cIWvKNrci" role="3cqZAk">
+                      <ref role="37wK5l" to="ivtb:2ycYXNhSb$u" resolve="negate" />
+                      <ref role="1Pybhc" to="ivtb:2ycYXNhRmBb" resolve="Negator" />
+                      <node concept="2OqwBi" id="78cIWvKNYeC" role="37wK5m">
+                        <node concept="Jnkvi" id="78cIWvKNYeD" role="2Oq$k0">
                           <ref role="1M0zk5" node="7sYf6NceYFP" resolve="cv" />
                         </node>
-                        <node concept="3TrEf2" id="7sYf6NceYFO" role="2OqNvi">
+                        <node concept="3TrEf2" id="78cIWvKNYeE" role="2OqNvi">
                           <ref role="3Tt5mk" to="vuki:42_2FftMOqp" resolve="conditie" />
                         </node>
                       </node>

--- a/languages/regelspraak/languageModels/regelspraak.translator.mps
+++ b/languages/regelspraak/languageModels/regelspraak.translator.mps
@@ -37304,25 +37304,14 @@
     <node concept="2YIFZL" id="2ycYXNhSb$u" role="jymVt">
       <property role="TrG5h" value="negate" />
       <node concept="3clFbS" id="2ycYXNhSb$x" role="3clF47">
-        <node concept="3cpWs8" id="2ycYXNwkUr9" role="3cqZAp">
-          <node concept="3cpWsn" id="2ycYXNwkUra" role="3cpWs9">
-            <property role="TrG5h" value="copy" />
-            <node concept="3Tqbb2" id="2ycYXNwkUnN" role="1tU5fm">
-              <ref role="ehGHo" to="m234:1ibElXOlZJv" resolve="Conditie" />
-            </node>
-            <node concept="2OqwBi" id="2ycYXNwkUrb" role="33vP2m">
-              <node concept="37vLTw" id="2ycYXNwkUrc" role="2Oq$k0">
-                <ref role="3cqZAo" node="2ycYXNhSb_q" resolve="conditie" />
-              </node>
-              <node concept="1$rogu" id="2ycYXNwkUrd" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs6" id="2ycYXNy6egS" role="3cqZAp">
           <node concept="1rXfSq" id="2ycYXNy6egU" role="3cqZAk">
             <ref role="37wK5l" node="2ycYXNlYmKM" resolve="replaceWithItsNegation" />
-            <node concept="37vLTw" id="2ycYXNy6egV" role="37wK5m">
-              <ref role="3cqZAo" node="2ycYXNwkUra" resolve="copy" />
+            <node concept="2OqwBi" id="78cIWvKVuH$" role="37wK5m">
+              <node concept="37vLTw" id="78cIWvKVuH_" role="2Oq$k0">
+                <ref role="3cqZAo" node="2ycYXNhSb_q" resolve="conditie" />
+              </node>
+              <node concept="1$rogu" id="78cIWvKVuHA" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -37367,6 +37356,36 @@
         <property role="TrG5h" value="conditie" />
         <node concept="3Tqbb2" id="2ycYXNlYmYJ" role="1tU5fm">
           <ref role="ehGHo" to="m234:1ibElXOlZJv" resolve="Conditie" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="78cIWvKD364" role="jymVt" />
+    <node concept="2YIFZL" id="78cIWvKlHGH" role="jymVt">
+      <property role="TrG5h" value="negatePredicate" />
+      <node concept="3clFbS" id="78cIWvKlHGI" role="3clF47">
+        <node concept="3clFbF" id="78cIWvKlLxa" role="3cqZAp">
+          <node concept="2OqwBi" id="78cIWvKlHGK" role="3clFbG">
+            <node concept="m3rhz" id="78cIWvKlHGL" role="2Oq$k0">
+              <ref role="m3rhy" node="1hAAHZWaoES" resolve="NegatingTranslator" />
+            </node>
+            <node concept="m3bmO" id="78cIWvKlHGM" role="2OqNvi">
+              <node concept="21Gwf3" id="78cIWvKlHGN" role="m3bmT">
+                <ref role="3qchXZ" node="2ycYXNvq6IF" resolve="replaceWithNegation" />
+                <ref role="37wK5l" node="2ycYXNvq_zl" resolve="abstractMapping_nodePredicaat" />
+                <node concept="37vLTw" id="78cIWvKlUUu" role="37wK5m">
+                  <ref role="3cqZAo" node="78cIWvKlHGR" resolve="predicate" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="78cIWvKlHGP" role="1B3o_S" />
+      <node concept="3cqZAl" id="78cIWvKU$NP" role="3clF45" />
+      <node concept="37vLTG" id="78cIWvKlHGR" role="3clF46">
+        <property role="TrG5h" value="predicate" />
+        <node concept="3Tqbb2" id="78cIWvKlHGS" role="1tU5fm">
+          <ref role="ehGHo" to="m234:R9Qv6IRKho" resolve="Predicaat" />
         </node>
       </node>
     </node>
@@ -37939,40 +37958,6 @@
             </node>
           </node>
         </node>
-        <node concept="21HLnp" id="2ycYXNvGYtz" role="jymVt">
-          <node concept="37vLTG" id="2ycYXNvGYt$" role="3clF46">
-            <property role="TrG5h" value="okb" />
-            <node concept="3Tqbb2" id="2ycYXNvH09S" role="1tU5fm">
-              <ref role="ehGHo" to="m234:6E7_KuSgO46" resolve="Ontkenbaar" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="2ycYXNvGYt_" role="3clF47">
-            <node concept="3clFbF" id="2ycYXNvH5ni" role="3cqZAp">
-              <node concept="37vLTI" id="2ycYXNvH5nj" role="3clFbG">
-                <node concept="3fqX7Q" id="2ycYXNvH5nk" role="37vLTx">
-                  <node concept="2OqwBi" id="2ycYXNvH5nl" role="3fr31v">
-                    <node concept="37vLTw" id="2ycYXNvH5nm" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2ycYXNvGYt$" resolve="okb" />
-                    </node>
-                    <node concept="3TrcHB" id="2ycYXNvH5nn" role="2OqNvi">
-                      <ref role="3TsBF5" to="m234:6E7_KuSgO47" resolve="ontkenning" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="2ycYXNvH5no" role="37vLTJ">
-                  <node concept="37vLTw" id="2ycYXNvH5np" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2ycYXNvGYt$" resolve="okb" />
-                  </node>
-                  <node concept="3TrcHB" id="2ycYXNvH5nq" role="2OqNvi">
-                    <ref role="3TsBF5" to="m234:6E7_KuSgO47" resolve="ontkenning" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="2ycYXNvGYtA" role="1B3o_S" />
-          <node concept="3cqZAl" id="2ycYXNvH1Bi" role="3clF45" />
-        </node>
         <node concept="21HLnp" id="2ycYXNvHaNs" role="jymVt">
           <node concept="37vLTG" id="2ycYXNvHaNt" role="3clF46">
             <property role="TrG5h" value="isLeeg" />
@@ -38043,14 +38028,103 @@
                     <ref role="3TsBF5" to="m234:5Q$2yZl7ALt" resolve="operator" />
                   </node>
                 </node>
-                <node concept="21Gwf3" id="2ycYXNvVvEZ" role="37vLTx">
-                  <ref role="37wK5l" node="2ycYXNvHaO2" resolve="mapping_enumVergelijkingsoperator" />
-                  <node concept="2OqwBi" id="2ycYXNvVFuU" role="37wK5m">
-                    <node concept="37vLTw" id="2ycYXNvV$Az" role="2Oq$k0">
+                <node concept="3X5UdL" id="78cIWvKDgxX" role="37vLTx">
+                  <node concept="2OqwBi" id="78cIWvKDjDf" role="3X5Ude">
+                    <node concept="37vLTw" id="78cIWvKDjDg" role="2Oq$k0">
                       <ref role="3cqZAo" node="2ycYXNvHaNJ" resolve="verg" />
                     </node>
-                    <node concept="3TrcHB" id="2ycYXNvVHYi" role="2OqNvi">
+                    <node concept="3TrcHB" id="78cIWvKDjDh" role="2OqNvi">
                       <ref role="3TsBF5" to="m234:5Q$2yZl7ALt" resolve="operator" />
+                    </node>
+                  </node>
+                  <node concept="3X5Udd" id="78cIWvKDgxZ" role="3X5gkp">
+                    <node concept="21nZrQ" id="78cIWvKDgy0" role="3X5Uda">
+                      <ref role="21nZrZ" to="m234:4WetKT2PyVQ" resolve="EQ" />
+                    </node>
+                    <node concept="3X5gDF" id="78cIWvKDgy1" role="3X5gFO">
+                      <node concept="2OqwBi" id="78cIWvKDgy2" role="3X5gDC">
+                        <node concept="1XH99k" id="78cIWvKDgy3" role="2Oq$k0">
+                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
+                        </node>
+                        <node concept="2ViDtV" id="78cIWvKDgy4" role="2OqNvi">
+                          <ref role="2ViDtZ" to="m234:4WetKT2PyVV" resolve="NE" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3X5Udd" id="78cIWvKDgy5" role="3X5gkp">
+                    <node concept="21nZrQ" id="78cIWvKDgy6" role="3X5Uda">
+                      <ref role="21nZrZ" to="m234:4WetKT2PyVV" resolve="NE" />
+                    </node>
+                    <node concept="3X5gDF" id="78cIWvKDgy7" role="3X5gFO">
+                      <node concept="2OqwBi" id="78cIWvKDgy8" role="3X5gDC">
+                        <node concept="1XH99k" id="78cIWvKDgy9" role="2Oq$k0">
+                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
+                        </node>
+                        <node concept="2ViDtV" id="78cIWvKDgya" role="2OqNvi">
+                          <ref role="2ViDtZ" to="m234:4WetKT2PyVQ" resolve="EQ" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3X5Udd" id="78cIWvKDgyb" role="3X5gkp">
+                    <node concept="21nZrQ" id="78cIWvKDgyc" role="3X5Uda">
+                      <ref role="21nZrZ" to="m234:4WetKT2PyVT" resolve="GT" />
+                    </node>
+                    <node concept="3X5gDF" id="78cIWvKDgyd" role="3X5gFO">
+                      <node concept="2OqwBi" id="78cIWvKDgye" role="3X5gDC">
+                        <node concept="1XH99k" id="78cIWvKDgyf" role="2Oq$k0">
+                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
+                        </node>
+                        <node concept="2ViDtV" id="78cIWvKDgyg" role="2OqNvi">
+                          <ref role="2ViDtZ" to="m234:4WetKT2PyVS" resolve="LE" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3X5Udd" id="78cIWvKDgyh" role="3X5gkp">
+                    <node concept="21nZrQ" id="78cIWvKDgyi" role="3X5Uda">
+                      <ref role="21nZrZ" to="m234:4WetKT2PyVU" resolve="GE" />
+                    </node>
+                    <node concept="3X5gDF" id="78cIWvKDgyj" role="3X5gFO">
+                      <node concept="2OqwBi" id="78cIWvKDgyk" role="3X5gDC">
+                        <node concept="1XH99k" id="78cIWvKDgyl" role="2Oq$k0">
+                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
+                        </node>
+                        <node concept="2ViDtV" id="78cIWvKDgym" role="2OqNvi">
+                          <ref role="2ViDtZ" to="m234:4WetKT2PyVR" resolve="LT" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3X5Udd" id="78cIWvKDgyn" role="3X5gkp">
+                    <node concept="21nZrQ" id="78cIWvKDgyo" role="3X5Uda">
+                      <ref role="21nZrZ" to="m234:4WetKT2PyVS" resolve="LE" />
+                    </node>
+                    <node concept="3X5gDF" id="78cIWvKDgyp" role="3X5gFO">
+                      <node concept="2OqwBi" id="78cIWvKDgyq" role="3X5gDC">
+                        <node concept="1XH99k" id="78cIWvKDgyr" role="2Oq$k0">
+                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
+                        </node>
+                        <node concept="2ViDtV" id="78cIWvKDgys" role="2OqNvi">
+                          <ref role="2ViDtZ" to="m234:4WetKT2PyVT" resolve="GT" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3X5Udd" id="78cIWvKDgyt" role="3X5gkp">
+                    <node concept="21nZrQ" id="78cIWvKDgyu" role="3X5Uda">
+                      <ref role="21nZrZ" to="m234:4WetKT2PyVR" resolve="LT" />
+                    </node>
+                    <node concept="3X5gDF" id="78cIWvKDgyv" role="3X5gFO">
+                      <node concept="2OqwBi" id="78cIWvKDgyw" role="3X5gDC">
+                        <node concept="1XH99k" id="78cIWvKDgyx" role="2Oq$k0">
+                          <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
+                        </node>
+                        <node concept="2ViDtV" id="78cIWvKDgyy" role="2OqNvi">
+                          <ref role="2ViDtZ" to="m234:4WetKT2PyVU" resolve="GE" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -38059,117 +38133,6 @@
           </node>
           <node concept="3Tm1VV" id="2ycYXNvHaO0" role="1B3o_S" />
           <node concept="3cqZAl" id="2ycYXNvIIf3" role="3clF45" />
-        </node>
-        <node concept="21HLnp" id="2ycYXNvHaO2" role="jymVt">
-          <node concept="37vLTG" id="2ycYXNvHaO3" role="3clF46">
-            <property role="TrG5h" value="op" />
-            <node concept="2ZThk1" id="2ycYXNvHaO4" role="1tU5fm">
-              <ref role="2ZWj4r" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="2ycYXNvHaO5" role="3clF47">
-            <node concept="3cpWs6" id="2ycYXNvHaO6" role="3cqZAp">
-              <node concept="3X5UdL" id="2ycYXNvHaO7" role="3cqZAk">
-                <node concept="37vLTw" id="2ycYXNvHaO8" role="3X5Ude">
-                  <ref role="3cqZAo" node="2ycYXNvHaO3" resolve="op" />
-                </node>
-                <node concept="3X5Udd" id="2ycYXNvHaO9" role="3X5gkp">
-                  <node concept="21nZrQ" id="2ycYXNvHaOa" role="3X5Uda">
-                    <ref role="21nZrZ" to="m234:4WetKT2PyVQ" resolve="EQ" />
-                  </node>
-                  <node concept="3X5gDF" id="2ycYXNvHaOb" role="3X5gFO">
-                    <node concept="2OqwBi" id="2ycYXNvHaOc" role="3X5gDC">
-                      <node concept="1XH99k" id="2ycYXNvHaOd" role="2Oq$k0">
-                        <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                      </node>
-                      <node concept="2ViDtV" id="2ycYXNvHaOe" role="2OqNvi">
-                        <ref role="2ViDtZ" to="m234:4WetKT2PyVV" resolve="NE" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3X5Udd" id="2ycYXNvHaOf" role="3X5gkp">
-                  <node concept="21nZrQ" id="2ycYXNvHaOg" role="3X5Uda">
-                    <ref role="21nZrZ" to="m234:4WetKT2PyVV" resolve="NE" />
-                  </node>
-                  <node concept="3X5gDF" id="2ycYXNvHaOh" role="3X5gFO">
-                    <node concept="2OqwBi" id="2ycYXNvHaOi" role="3X5gDC">
-                      <node concept="1XH99k" id="2ycYXNvHaOj" role="2Oq$k0">
-                        <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                      </node>
-                      <node concept="2ViDtV" id="2ycYXNvHaOk" role="2OqNvi">
-                        <ref role="2ViDtZ" to="m234:4WetKT2PyVQ" resolve="EQ" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3X5Udd" id="2ycYXNvHaOl" role="3X5gkp">
-                  <node concept="21nZrQ" id="2ycYXNvHaOm" role="3X5Uda">
-                    <ref role="21nZrZ" to="m234:4WetKT2PyVT" resolve="GT" />
-                  </node>
-                  <node concept="3X5gDF" id="2ycYXNvHaOn" role="3X5gFO">
-                    <node concept="2OqwBi" id="2ycYXNvHaOo" role="3X5gDC">
-                      <node concept="1XH99k" id="2ycYXNvHaOp" role="2Oq$k0">
-                        <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                      </node>
-                      <node concept="2ViDtV" id="2ycYXNvHaOq" role="2OqNvi">
-                        <ref role="2ViDtZ" to="m234:4WetKT2PyVS" resolve="LE" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3X5Udd" id="2ycYXNvHaOr" role="3X5gkp">
-                  <node concept="21nZrQ" id="2ycYXNvHaOs" role="3X5Uda">
-                    <ref role="21nZrZ" to="m234:4WetKT2PyVU" resolve="GE" />
-                  </node>
-                  <node concept="3X5gDF" id="2ycYXNvHaOt" role="3X5gFO">
-                    <node concept="2OqwBi" id="2ycYXNvHaOu" role="3X5gDC">
-                      <node concept="1XH99k" id="2ycYXNvHaOv" role="2Oq$k0">
-                        <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                      </node>
-                      <node concept="2ViDtV" id="2ycYXNvHaOw" role="2OqNvi">
-                        <ref role="2ViDtZ" to="m234:4WetKT2PyVR" resolve="LT" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3X5Udd" id="2ycYXNvHaOx" role="3X5gkp">
-                  <node concept="21nZrQ" id="2ycYXNvHaOy" role="3X5Uda">
-                    <ref role="21nZrZ" to="m234:4WetKT2PyVS" resolve="LE" />
-                  </node>
-                  <node concept="3X5gDF" id="2ycYXNvHaOz" role="3X5gFO">
-                    <node concept="2OqwBi" id="2ycYXNvHaO$" role="3X5gDC">
-                      <node concept="1XH99k" id="2ycYXNvHaO_" role="2Oq$k0">
-                        <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                      </node>
-                      <node concept="2ViDtV" id="2ycYXNvHaOA" role="2OqNvi">
-                        <ref role="2ViDtZ" to="m234:4WetKT2PyVT" resolve="GT" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3X5Udd" id="2ycYXNvHaOB" role="3X5gkp">
-                  <node concept="21nZrQ" id="2ycYXNvHaOC" role="3X5Uda">
-                    <ref role="21nZrZ" to="m234:4WetKT2PyVR" resolve="LT" />
-                  </node>
-                  <node concept="3X5gDF" id="2ycYXNvHaOD" role="3X5gFO">
-                    <node concept="2OqwBi" id="2ycYXNvHaOE" role="3X5gDC">
-                      <node concept="1XH99k" id="2ycYXNvHaOF" role="2Oq$k0">
-                        <ref role="1XH99l" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-                      </node>
-                      <node concept="2ViDtV" id="2ycYXNvHaOG" role="2OqNvi">
-                        <ref role="2ViDtZ" to="m234:4WetKT2PyVU" resolve="GE" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="2ycYXNvHaOH" role="1B3o_S" />
-          <node concept="2ZThk1" id="2ycYXNvHaOI" role="3clF45">
-            <ref role="2ZWj4r" to="m234:4WetKT2PyVO" resolve="Vergelijkingsoperator" />
-          </node>
         </node>
         <node concept="21HLnp" id="2ycYXNvHaOJ" role="jymVt">
           <node concept="37vLTG" id="2ycYXNvHaOK" role="3clF46">

--- a/solutions/Beslistabellen_Test/models/Beslistabellen_Test.gebruik@tests.mps
+++ b/solutions/Beslistabellen_Test/models/Beslistabellen_Test.gebruik@tests.mps
@@ -18,7 +18,11 @@
     <import index="m234" ref="r:dab861ec-284c-4992-a98c-1e3b9c9dd555(regelspraak.structure)" />
     <import index="3ic2" ref="r:1be64251-a392-4bb4-8ecb-06d30a9277a4(gegevensspraak.structure)" />
     <import index="ydsj" ref="r:9b861841-b485-4004-934e-28ca5d3b78dc(Beslistabellen_Test.ALEF4336)" />
+    <import index="vuki" ref="r:9d8fdbe6-7bc1-4b58-82df-212f1d42dd13(beslistabelspraak.structure)" />
+    <import index="e9uq" ref="r:872814fd-6207-43ae-992c-cc24a8332815(Beslistabellen_Test.tabellen)" />
+    <import index="qrag" ref="r:02cd4216-da43-4a72-8ef1-a35a8a90e696(beslistabelspraak.translator)" />
     <import index="ykqi" ref="r:c71b9efb-c880-476d-a07a-2493b4c1967f(gegevensspraak.base)" implicit="true" />
+    <import index="r8y1" ref="r:4680c30b-05e7-4df0-ba11-8c74e0c26486(beslistabelspraak.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -47,6 +51,7 @@
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
@@ -68,21 +73,30 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
@@ -111,6 +125,9 @@
         <property id="7850059172684106641" name="hoeAfTeRonden" index="29kKyC" />
         <child id="7850059172684106683" name="afTeRonden" index="29kKy2" />
       </concept>
+      <concept id="653687101152476040" name="regelspraak.structure.ParameterRef" flags="ng" index="2boetW">
+        <reference id="653687101152476041" name="param" index="2boetX" />
+      </concept>
       <concept id="347899601029311684" name="regelspraak.structure.AttribuutSelector" flags="ng" index="c2t0s" />
       <concept id="6223277501270327848" name="regelspraak.structure.AbstracteRegel" flags="ng" index="nISv2">
         <child id="6223277501273432772" name="versie" index="kiesI" />
@@ -132,10 +149,12 @@
       <concept id="8116110704340985492" name="regelspraak.structure.Worteltrekken" flags="ng" index="LnP4V">
         <child id="8116110704340985505" name="radicand" index="LnP4e" />
       </concept>
+      <concept id="6717268411822268012" name="regelspraak.structure.PercentageVanExpressie" flags="ng" index="2QDHpF" />
       <concept id="5696347358893285502" name="regelspraak.structure.ISelectie" flags="ngI" index="137dR0">
         <child id="6774523643279660910" name="selector" index="eaaoM" />
         <child id="9009487889885775372" name="object" index="pQQuc" />
       </concept>
+      <concept id="1690542669507072389" name="regelspraak.structure.MinusExpressie" flags="ng" index="3aUx8s" />
       <concept id="1690542669507072391" name="regelspraak.structure.VermenigvuldigExpressie" flags="ng" index="3aUx8u" />
       <concept id="1690542669507072390" name="regelspraak.structure.PlusExpressie" flags="ng" index="3aUx8v" />
       <concept id="1024280404772184160" name="regelspraak.structure.OnderwerpRef" flags="ng" index="3yS1BT">
@@ -148,6 +167,16 @@
       <concept id="1024280404748412380" name="regelspraak.structure.Selectie" flags="ng" index="3_mHL5" />
       <concept id="5128603206711845672" name="regelspraak.structure.DelenExpressie" flags="ng" index="3IOlpp" />
     </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
         <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
@@ -157,6 +186,11 @@
       </concept>
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
@@ -166,9 +200,21 @@
       <concept id="1172028177041" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNull" flags="nn" index="3ykFI1">
         <child id="1172028236559" name="expression" index="3ykU8v" />
       </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
     </language>
     <language id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak">
-      <concept id="5478077304742085581" name="gegevensspraak.structure.Geldigheidsperiode" flags="ng" index="2ljwA5" />
+      <concept id="5478077304742291705" name="gegevensspraak.structure.DatumTijdLiteral" flags="ng" index="2ljiaL">
+        <property id="5478077304742291708" name="jaar" index="2ljiaO" />
+      </concept>
+      <concept id="5478077304742085581" name="gegevensspraak.structure.Geldigheidsperiode" flags="ng" index="2ljwA5">
+        <child id="5478077304742085582" name="van" index="2ljwA6" />
+        <child id="5478077304742085583" name="tm" index="2ljwA7" />
+      </concept>
       <concept id="4697074533531324619" name="gegevensspraak.structure.BooleanLiteral" flags="ng" index="2Jx4MH">
         <property id="4697074533531324626" name="waarde" index="2Jx4MO" />
       </concept>
@@ -183,6 +229,7 @@
       <concept id="8989128614611296432" name="gegevensspraak.structure.EnumWaardeRef" flags="ng" index="16yQLD">
         <reference id="8989128614611340128" name="waarde" index="16yCuT" />
       </concept>
+      <concept id="558527188491918355" name="gegevensspraak.structure.PercentageLiteral" flags="ng" index="3cHhmn" />
       <concept id="558527188464633210" name="gegevensspraak.structure.AbstractNumeriekeLiteral" flags="ng" index="3e5kNY">
         <property id="558527188465081158" name="waarde" index="3e6Tb2" />
         <child id="1600719477559844899" name="eenheid" index="1jdwn1" />
@@ -203,6 +250,7 @@
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -248,6 +296,7 @@
       <concept id="865448068629309593" name="beslistabelspraak.structure.BtBoolConditie" flags="ng" index="3ic1zR">
         <child id="865448068629309594" name="voorwaarde" index="3ic1zO" />
       </concept>
+      <concept id="5065940080638786866" name="beslistabelspraak.structure.NietVanToepassing" flags="ng" index="3DFEyr" />
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -256,6 +305,9 @@
       <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
     </language>
   </registry>
   <node concept="2XOHcx" id="497icNAbVyC">
@@ -1268,6 +1320,620 @@
     <node concept="3clFbS" id="4l3Epmu2TF7" role="LjaKd">
       <node concept="1MFPAf" id="4l3Epmu2TGB" role="3cqZAp">
         <ref role="1MFYO6" to="bf83:9lV$l9duLt" resolve="VerwijderConditieKolom" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="1UCOV1PpOlI">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="BeslistabelDesugar" />
+    <node concept="1qefOq" id="1UCOV1PJ2JN" role="1SKRRt">
+      <node concept="i4t92" id="1UCOV1PJ2QF" role="1qenE9">
+        <property role="TrG5h" value="Tables" />
+        <node concept="2X3mv7" id="70BIiIg6tWy" role="kiesI">
+          <node concept="2X3ifB" id="70BIiIg6tWz" role="2X3ifz">
+            <node concept="3_mHL5" id="70BIiIg6tW$" role="2mKM6d">
+              <node concept="c2t0s" id="70BIiIg6tW_" role="eaaoM">
+                <ref role="Qu8KH" to="e9uq:70BIiIg6fN0" resolve="payment" />
+              </node>
+              <node concept="3_kdyS" id="70BIiIg6tWA" role="pQQuc">
+                <ref role="Qu8KH" to="e9uq:70BIiIg6fMZ" resolve="Person" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3ifT" id="70BIiIg6tWB" role="2X3ifS">
+            <property role="2X3IFY" value="5brrC35IcX$/GT" />
+            <node concept="3_mHL5" id="70BIiIg6tWC" role="2oUl7d">
+              <node concept="c2t0s" id="70BIiIg6tWD" role="eaaoM">
+                <ref role="Qu8KH" to="e9uq:70BIiIg6fUn" resolve="age" />
+              </node>
+              <node concept="3yS1BT" id="70BIiIg6tWE" role="pQQuc">
+                <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3ifT" id="70BIiIg6tWF" role="2X3ifS">
+            <property role="2X3IFY" value="5brrC35IcXw/LE" />
+            <node concept="3_mHL5" id="70BIiIg6tWG" role="2oUl7d">
+              <node concept="c2t0s" id="70BIiIg6tWH" role="eaaoM">
+                <ref role="Qu8KH" to="e9uq:70BIiIg6fUn" resolve="age" />
+              </node>
+              <node concept="3yS1BT" id="70BIiIg6tWI" role="pQQuc">
+                <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="70BIiIg6tWJ" role="2X3ifY">
+            <node concept="2W9DTK" id="70BIiIg6tWK" role="2X3DpX">
+              <ref role="2Wjr0C" node="70BIiIg6tWB" />
+              <node concept="3DFEyr" id="70BIiIg6tWL" role="19Qu69" />
+            </node>
+            <node concept="2W9DTK" id="70BIiIg6tWM" role="2X3DpX">
+              <ref role="2Wjr0C" node="70BIiIg6tWF" />
+              <node concept="1EQTEq" id="70BIiIg6tWN" role="19Qu69">
+                <property role="3e6Tb2" value="18" />
+              </node>
+            </node>
+            <node concept="19B5yA" id="70BIiIg6tWO" role="2X3DpX">
+              <ref role="19B5yx" node="70BIiIg6tWz" />
+              <node concept="2QDHpF" id="70BIiIg6uh4" role="19Qu69">
+                <node concept="3cHhmn" id="70BIiIg6u_E" role="2C$i6h">
+                  <property role="3e6Tb2" value="100" />
+                </node>
+                <node concept="3_mHL5" id="70BIiIg6tWP" role="2C$i6l">
+                  <node concept="c2t0s" id="70BIiIg6tWQ" role="eaaoM">
+                    <ref role="Qu8KH" to="e9uq:70BIiIg6fSN" resolve="income" />
+                  </node>
+                  <node concept="3yS1BT" id="70BIiIg6tWR" role="pQQuc">
+                    <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="70BIiIg6tWS" role="2X3ifY">
+            <node concept="2W9DTK" id="70BIiIg6tWT" role="2X3DpX">
+              <ref role="2Wjr0C" node="70BIiIg6tWB" />
+              <node concept="1EQTEq" id="70BIiIg6tWU" role="19Qu69">
+                <property role="3e6Tb2" value="18" />
+              </node>
+            </node>
+            <node concept="2W9DTK" id="70BIiIg6tWV" role="2X3DpX">
+              <ref role="2Wjr0C" node="70BIiIg6tWF" />
+              <node concept="1EQTEq" id="70BIiIg6tWW" role="19Qu69">
+                <property role="3e6Tb2" value="65" />
+              </node>
+            </node>
+            <node concept="19B5yA" id="70BIiIg6tWX" role="2X3DpX">
+              <ref role="19B5yx" node="70BIiIg6tWz" />
+              <node concept="2QDHpF" id="70BIiIg6uJQ" role="19Qu69">
+                <node concept="3cHhmn" id="70BIiIg6uJR" role="2C$i6h">
+                  <property role="3e6Tb2" value="50" />
+                </node>
+                <node concept="3_mHL5" id="70BIiIg6uJS" role="2C$i6l">
+                  <node concept="c2t0s" id="70BIiIg6uJT" role="eaaoM">
+                    <ref role="Qu8KH" to="e9uq:70BIiIg6fSN" resolve="income" />
+                  </node>
+                  <node concept="3yS1BT" id="70BIiIg6uJU" role="pQQuc">
+                    <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="70BIiIg6tX1" role="2X3ifY">
+            <node concept="2W9DTK" id="70BIiIg6tX2" role="2X3DpX">
+              <ref role="2Wjr0C" node="70BIiIg6tWB" />
+              <node concept="1EQTEq" id="70BIiIg6tX3" role="19Qu69">
+                <property role="3e6Tb2" value="65" />
+              </node>
+            </node>
+            <node concept="2W9DTK" id="70BIiIg6tX4" role="2X3DpX">
+              <ref role="2Wjr0C" node="70BIiIg6tWF" />
+              <node concept="3DFEyr" id="70BIiIg6tX5" role="19Qu69" />
+            </node>
+            <node concept="19B5yA" id="70BIiIg6tX6" role="2X3DpX">
+              <ref role="19B5yx" node="70BIiIg6tWz" />
+              <node concept="2QDHpF" id="70BIiIg6uMO" role="19Qu69">
+                <node concept="3cHhmn" id="70BIiIg6uMP" role="2C$i6h">
+                  <property role="3e6Tb2" value="10" />
+                </node>
+                <node concept="3_mHL5" id="70BIiIg6uMQ" role="2C$i6l">
+                  <node concept="c2t0s" id="70BIiIg6uMR" role="eaaoM">
+                    <ref role="Qu8KH" to="e9uq:70BIiIg6fSN" resolve="income" />
+                  </node>
+                  <node concept="3yS1BT" id="70BIiIg6uMS" role="pQQuc">
+                    <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ljwA5" id="70BIiIg6tXa" role="1nvPAL">
+            <node concept="2ljiaL" id="1UCOV1PJ30h" role="2ljwA6">
+              <property role="2ljiaO" value="2001" />
+            </node>
+            <node concept="2ljiaL" id="1UCOV1PJ30i" role="2ljwA7">
+              <property role="2ljiaO" value="2001" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="1UCOV1PJ3RH" role="lGtFl">
+            <property role="TrG5h" value="tv1" />
+          </node>
+        </node>
+        <node concept="2X3mv7" id="1UCOV1PJ50E" role="kiesI">
+          <node concept="2X3ifB" id="1UCOV1PJ50F" role="2X3ifz">
+            <node concept="3_mHL5" id="1UCOV1PJ50G" role="2mKM6d">
+              <node concept="3_kdyS" id="1UCOV1PJ50H" role="pQQuc">
+                <ref role="Qu8KH" to="bwda:12kR7KmQyAE" resolve="proces" />
+              </node>
+              <node concept="c2t0s" id="1UCOV1PJ50I" role="eaaoM">
+                <ref role="Qu8KH" to="bwda:12kR7KmQyBb" resolve="output" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3ifT" id="1UCOV1PJ50J" role="2X3ifS">
+            <property role="2X3IFY" value="5brrC35IcXD/GE" />
+            <node concept="3_mHL5" id="1UCOV1PJ50K" role="2oUl7d">
+              <node concept="c2t0s" id="1UCOV1PJ50L" role="eaaoM">
+                <ref role="Qu8KH" to="bwda:12kR7KmQyDe" resolve="input" />
+              </node>
+              <node concept="3yS1BT" id="1UCOV1PJ50M" role="pQQuc">
+                <ref role="3yS1Ki" node="1UCOV1PJ50H" resolve="proces" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3ifT" id="6$TxEtr8EDP" role="2X3ifS">
+            <property role="2X3IFY" value="5brrC35IcXt/LT" />
+            <node concept="3_mHL5" id="6$TxEtr8EDQ" role="2oUl7d">
+              <node concept="c2t0s" id="6$TxEtr8EKU" role="eaaoM">
+                <ref role="Qu8KH" to="bwda:12kR7KmQyDe" resolve="input" />
+              </node>
+              <node concept="3yS1BT" id="6$TxEtr8EKT" role="pQQuc">
+                <ref role="3yS1Ki" node="1UCOV1PJ50H" resolve="proces" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="1UCOV1PJ50N" role="2X3ifY">
+            <node concept="2W9DTK" id="1UCOV1PJ50O" role="2X3DpX">
+              <ref role="2Wjr0C" node="1UCOV1PJ50J" />
+              <node concept="1EQTEq" id="1UCOV1PJ50P" role="19Qu69">
+                <property role="3e6Tb2" value="0" />
+                <node concept="PwxsY" id="5LmhQNiahMz" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahMy" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="19B5yA" id="1UCOV1PJ50Q" role="2X3DpX">
+              <ref role="19B5yx" node="1UCOV1PJ50F" />
+              <node concept="3_mHL5" id="1UCOV1PJ50R" role="19Qu69">
+                <node concept="c2t0s" id="1UCOV1PJ50S" role="eaaoM">
+                  <ref role="Qu8KH" to="bwda:12kR7KmQyDe" resolve="input" />
+                </node>
+                <node concept="3yS1BT" id="1UCOV1PJ50T" role="pQQuc">
+                  <ref role="3yS1Ki" node="1UCOV1PJ50H" resolve="proces" />
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="6$TxEtr8EDU" role="2X3DpX">
+              <ref role="2Wjr0C" node="6$TxEtr8EDP" />
+              <node concept="1EQTEq" id="6$TxEtr8F6z" role="19Qu69">
+                <property role="3e6Tb2" value="2" />
+                <node concept="PwxsY" id="5LmhQNiahMP" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahMO" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="6twVtZEHP2U" role="2X3ifY">
+            <node concept="19B5yA" id="6twVtZEHP2Y" role="2X3DpX">
+              <ref role="19B5yx" node="1UCOV1PJ50F" />
+              <node concept="3aUx8u" id="6$TxEtq1Kys" role="19Qu69">
+                <node concept="1EQTEq" id="6$TxEtq1K_U" role="2C$i6l">
+                  <property role="3e6Tb2" value="2" />
+                </node>
+                <node concept="3_mHL5" id="6twVtZEHP7$" role="2C$i6h">
+                  <node concept="c2t0s" id="6twVtZEHP8z" role="eaaoM">
+                    <ref role="Qu8KH" to="bwda:12kR7KmQyDe" resolve="input" />
+                  </node>
+                  <node concept="3yS1BT" id="6twVtZEHP8y" role="pQQuc">
+                    <ref role="3yS1Ki" node="1UCOV1PJ50H" resolve="proces" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="6twVtZEHP2V" role="2X3DpX">
+              <ref role="2Wjr0C" node="1UCOV1PJ50J" />
+              <node concept="1EQTEq" id="6$TxEtr8Fmo" role="19Qu69">
+                <property role="3e6Tb2" value="2" />
+                <node concept="PwxsY" id="5LmhQNiahNo" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahNn" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="6$TxEtr8EDX" role="2X3DpX">
+              <ref role="2Wjr0C" node="6$TxEtr8EDP" />
+              <node concept="2boetW" id="6$TxEtr8FeU" role="19Qu69">
+                <ref role="2boetX" to="bwda:6twVtZEHOOZ" resolve="GRENS" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="6$TxEtr7W_P" role="2X3ifY">
+            <node concept="2W9DTK" id="6$TxEtr7W_Q" role="2X3DpX">
+              <ref role="2Wjr0C" node="1UCOV1PJ50J" />
+              <node concept="2boetW" id="6$TxEtr8FUc" role="19Qu69">
+                <ref role="2boetX" to="bwda:6twVtZEHOOZ" resolve="GRENS" />
+              </node>
+            </node>
+            <node concept="19B5yA" id="6$TxEtr7W_T" role="2X3DpX">
+              <ref role="19B5yx" node="1UCOV1PJ50F" />
+              <node concept="1EQTEq" id="6$TxEtr7W_V" role="19Qu69">
+                <property role="3e6Tb2" value="1" />
+                <node concept="PwxsY" id="5LmhQNiahNE" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahND" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy__" resolve="joule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="6$TxEtr8EE0" role="2X3DpX">
+              <ref role="2Wjr0C" node="6$TxEtr8EDP" />
+              <node concept="1EQTEq" id="6$TxEtr8FB$" role="19Qu69">
+                <property role="3e6Tb2" value="10000" />
+                <node concept="PwxsY" id="5LmhQNiahNW" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahNV" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="7PZpO9lK4Ig" role="2X3ifY">
+            <node concept="2W9DTK" id="7PZpO9lK4Ih" role="2X3DpX">
+              <ref role="2Wjr0C" node="1UCOV1PJ50J" />
+              <node concept="1EQTEq" id="7PZpO9lK4Ij" role="19Qu69">
+                <property role="3e6Tb2" value="14000" />
+                <node concept="PwxsY" id="5LmhQNiahOe" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahOd" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="7PZpO9lK4Ik" role="2X3DpX">
+              <ref role="2Wjr0C" node="6$TxEtr8EDP" />
+              <node concept="1EQTEq" id="7PZpO9lK4Im" role="19Qu69">
+                <property role="3e6Tb2" value="15000" />
+                <node concept="PwxsY" id="5LmhQNiahOw" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahOv" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="19B5yA" id="7PZpO9lK4In" role="2X3DpX">
+              <ref role="19B5yx" node="1UCOV1PJ50F" />
+              <node concept="29kKyO" id="1UCOV1PJ50U" role="19Qu69">
+                <property role="29kKyC" value="6NL0NB_CwIl/rekenkundig_afgerond" />
+                <property role="29kKyf" value="0" />
+                <node concept="1qsXiz" id="1UCOV1PJ50V" role="29kKy2">
+                  <node concept="2E1DPt" id="1UCOV1PJ50W" role="1qsXiG">
+                    <node concept="LnP4V" id="1UCOV1PJ50X" role="2CAJk9">
+                      <node concept="1EQTEq" id="1UCOV1PJ50Y" role="LnP4e">
+                        <property role="3e6Tb2" value="18" />
+                        <node concept="PwxsY" id="7PZpO9lKoNx" role="1jdwn1">
+                          <node concept="Pwxi7" id="7PZpO9lKoUn" role="Pwxi2">
+                            <property role="Pwxi6" value="2" />
+                            <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="PwxsY" id="1UCOV1PJ50Z" role="1qsXiI">
+                    <node concept="Pwxi7" id="1UCOV1PJ510" role="Pwxi2">
+                      <property role="Pwxi6" value="1" />
+                      <ref role="Pwxi0" to="bwda:12kR7KmQy__" resolve="joule" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="7PZpO9qmJg0" role="2X3ifY">
+            <node concept="2W9DTK" id="7PZpO9qmJg1" role="2X3DpX">
+              <ref role="2Wjr0C" node="1UCOV1PJ50J" />
+              <node concept="1EQTEq" id="7PZpO9qmJg3" role="19Qu69">
+                <property role="3e6Tb2" value="15000" />
+                <node concept="PwxsY" id="5LmhQNiahOM" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahOL" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="7PZpO9qmJg4" role="2X3DpX">
+              <ref role="2Wjr0C" node="6$TxEtr8EDP" />
+              <node concept="1EQTEq" id="7PZpO9qmJg6" role="19Qu69">
+                <property role="3e6Tb2" value="16000" />
+                <node concept="PwxsY" id="5LmhQNiahP4" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahP3" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="19B5yA" id="7PZpO9qmJg7" role="2X3DpX">
+              <ref role="19B5yx" node="1UCOV1PJ50F" />
+              <node concept="29kKyO" id="7PZpO9qmJ$W" role="19Qu69">
+                <property role="29kKyC" value="6NL0NB_CwIl/rekenkundig_afgerond" />
+                <property role="29kKyf" value="0" />
+                <node concept="2E1DPt" id="7PZpO9qmJMx" role="29kKy2">
+                  <node concept="1qsXiz" id="7PZpO9qmJMy" role="2CAJk9">
+                    <node concept="2E1DPt" id="7PZpO9qmJMz" role="1qsXiG">
+                      <node concept="LnP4V" id="7PZpO9qmJM$" role="2CAJk9">
+                        <node concept="1EQTEq" id="7PZpO9qmJM_" role="LnP4e">
+                          <property role="3e6Tb2" value="28" />
+                          <node concept="PwxsY" id="7PZpO9qmJMA" role="1jdwn1">
+                            <node concept="Pwxi7" id="7PZpO9qmJMB" role="Pwxi2">
+                              <property role="Pwxi6" value="2" />
+                              <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="PwxsY" id="7PZpO9qmJMC" role="1qsXiI">
+                      <node concept="Pwxi7" id="7PZpO9qmJMD" role="Pwxi2">
+                        <property role="Pwxi6" value="1" />
+                        <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2X3DpY" id="7PZpO9rgwWt" role="2X3ifY">
+            <node concept="2W9DTK" id="7PZpO9rgwWu" role="2X3DpX">
+              <ref role="2Wjr0C" node="1UCOV1PJ50J" />
+              <node concept="1EQTEq" id="7PZpO9rgwWw" role="19Qu69">
+                <property role="3e6Tb2" value="16000" />
+                <node concept="PwxsY" id="5LmhQNiahPm" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahPl" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2W9DTK" id="7PZpO9rgwWx" role="2X3DpX">
+              <ref role="2Wjr0C" node="6$TxEtr8EDP" />
+              <node concept="1EQTEq" id="7PZpO9rgwWz" role="19Qu69">
+                <property role="3e6Tb2" value="17000" />
+                <node concept="PwxsY" id="5LmhQNiahPC" role="1jdwn1">
+                  <node concept="Pwxi7" id="5LmhQNiahPB" role="Pwxi2">
+                    <property role="Pwxi6" value="1" />
+                    <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="19B5yA" id="7PZpO9rgwW$" role="2X3DpX">
+              <ref role="19B5yx" node="1UCOV1PJ50F" />
+              <node concept="3aUx8v" id="7PZpO9rgxq2" role="19Qu69">
+                <node concept="1EQTEq" id="7PZpO9rgxwv" role="2C$i6h">
+                  <property role="3e6Tb2" value="5" />
+                  <node concept="PwxsY" id="5LmhQNiahPU" role="1jdwn1">
+                    <node concept="Pwxi7" id="5LmhQNiahPT" role="Pwxi2">
+                      <property role="Pwxi6" value="1" />
+                      <ref role="Pwxi0" to="bwda:12kR7KmQy__" resolve="joule" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3aUx8s" id="7PZpO9rgxV1" role="2C$i6l">
+                  <node concept="1EQTEq" id="7PZpO9rgy3f" role="2C$i6h">
+                    <property role="3e6Tb2" value="4" />
+                    <node concept="PwxsY" id="7PZpO9rgyp2" role="1jdwn1">
+                      <node concept="Pwxi7" id="7PZpO9rgyyT" role="Pwxi2">
+                        <property role="Pwxi6" value="1" />
+                        <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1EQTEq" id="7PZpO9rgycP" role="2C$i6l">
+                    <property role="3e6Tb2" value="1" />
+                    <node concept="PwxsY" id="7PZpO9rgyMf" role="1jdwn1">
+                      <node concept="Pwxi7" id="7PZpO9rgyVs" role="Pwxi2">
+                        <property role="Pwxi6" value="1" />
+                        <ref role="Pwxi0" to="bwda:12kR7KmQy_N" resolve="kilojoule" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ljwA5" id="1UCOV1PJ511" role="1nvPAL">
+            <node concept="2ljiaL" id="1UCOV1PJ5v1" role="2ljwA6">
+              <property role="2ljiaO" value="2002" />
+            </node>
+            <node concept="2ljiaL" id="1UCOV1PJ5v2" role="2ljwA7">
+              <property role="2ljiaO" value="2002" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="1UCOV1PJ5HI" role="lGtFl">
+            <property role="TrG5h" value="tv2" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="1UCOV1PD6tH" role="1qtyYc">
+      <property role="TrG5h" value="DesugarDoesNotCauseChanges" />
+      <node concept="37vLTG" id="1UCOV1PD6GQ" role="3clF46">
+        <property role="TrG5h" value="original" />
+        <node concept="3Tqbb2" id="1UCOV1PD6In" role="1tU5fm">
+          <ref role="ehGHo" to="vuki:4u4QrfUyrTO" resolve="BeslistabelVersie" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="1UCOV1PD6Aq" role="3clF45" />
+      <node concept="3clFbS" id="1UCOV1PD6tJ" role="3clF47">
+        <node concept="3cpWs8" id="1UCOV1PD6As" role="3cqZAp">
+          <node concept="3cpWsn" id="1UCOV1PD6At" role="3cpWs9">
+            <property role="TrG5h" value="test" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3Tqbb2" id="1UCOV1PD6Au" role="1tU5fm">
+              <ref role="ehGHo" to="vuki:4u4QrfUyrTO" resolve="BeslistabelVersie" />
+            </node>
+            <node concept="2OqwBi" id="1UCOV1PD6Av" role="33vP2m">
+              <node concept="37vLTw" id="1UCOV1PD6EI" role="2Oq$k0">
+                <ref role="3cqZAo" node="1UCOV1PD6GQ" resolve="original" />
+              </node>
+              <node concept="1$rogu" id="1UCOV1PD6Ax" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1UCOV1PD6Ay" role="3cqZAp">
+          <node concept="3_1$Yv" id="1UCOV1PD6A$" role="3_9lra">
+            <node concept="Xl_RD" id="1UCOV1PD6A_" role="3_1BAH">
+              <property role="Xl_RC" value="Unexpected number of rules for table" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1UCOV1PD6AA" role="3tpDZA">
+            <node concept="2YIFZM" id="1UCOV1PD6AB" role="2Oq$k0">
+              <ref role="37wK5l" to="qrag:3IlNR$ICLek" resolve="desugar" />
+              <ref role="1Pybhc" to="qrag:3IlNR$ICLbm" resolve="Beslistabel" />
+              <node concept="37vLTw" id="1UCOV1PD6AC" role="37wK5m">
+                <ref role="3cqZAo" node="1UCOV1PD6At" resolve="test" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="1UCOV1PD6AD" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="1UCOV1PDiPE" role="3tpDZB">
+            <node concept="37vLTw" id="1UCOV1PDhKP" role="2Oq$k0">
+              <ref role="3cqZAo" node="1UCOV1PD6GQ" resolve="original" />
+            </node>
+            <node concept="2qgKlT" id="1UCOV1PDjBm" role="2OqNvi">
+              <ref role="37wK5l" to="r8y1:9lV$lbKSVS" resolve="aantalRijen" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="1UCOV1PD6AE" role="3cqZAp">
+          <node concept="1PaTwC" id="1UCOV1PD6AF" role="1aUNEU">
+            <node concept="3oM_SD" id="1UCOV1PD6AG" role="1PaTwD">
+              <property role="3oM_SC" value="Don't" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AH" role="1PaTwD">
+              <property role="3oM_SC" value="know" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AI" role="1PaTwD">
+              <property role="3oM_SC" value="how" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAlVt" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAlVu" role="1PaTwD">
+              <property role="3oM_SC" value="enfoce" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAlVv" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AO" role="1PaTwD">
+              <property role="3oM_SC" value="read-only" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AP" role="1PaTwD">
+              <property role="3oM_SC" value="node-tree" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AQ" role="1PaTwD">
+              <property role="3oM_SC" value="but" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AR" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AS" role="1PaTwD">
+              <property role="3oM_SC" value="match" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAmEB" role="1PaTwD">
+              <property role="3oM_SC" value="below" />
+            </node>
+            <node concept="3oM_SD" id="1UCOV1PD6AV" role="1PaTwD">
+              <property role="3oM_SC" value="catches" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAmEG" role="1PaTwD">
+              <property role="3oM_SC" value="(the" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAmEH" role="1PaTwD">
+              <property role="3oM_SC" value="actual)" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAlVw" role="1PaTwD">
+              <property role="3oM_SC" value="changes" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAmEC" role="1PaTwD">
+              <property role="3oM_SC" value="(that" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAmED" role="1PaTwD">
+              <property role="3oM_SC" value="happened" />
+            </node>
+            <node concept="3oM_SD" id="2LMJTgRAmEE" role="1PaTwD">
+              <property role="3oM_SC" value="before)." />
+            </node>
+          </node>
+        </node>
+        <node concept="JA50E" id="1UCOV1PD6AX" role="3cqZAp">
+          <node concept="37vLTw" id="1UCOV1PD6EJ" role="JA92f">
+            <ref role="3cqZAo" node="1UCOV1PD6GQ" resolve="original" />
+          </node>
+          <node concept="37vLTw" id="1UCOV1PD6AZ" role="JAdkl">
+            <ref role="3cqZAo" node="1UCOV1PD6At" resolve="test" />
+          </node>
+          <node concept="3_1$Yv" id="1UCOV1PD6B0" role="3_9lra">
+            <node concept="Xl_RD" id="1UCOV1PD6B1" role="3_1BAH">
+              <property role="Xl_RC" value="Unexpected changes made during desugaring" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1UCOV1PpOyL" role="1SL9yI">
+      <property role="TrG5h" value="DesugarPreservesTheOriginal" />
+      <node concept="3cqZAl" id="1UCOV1PpOyM" role="3clF45" />
+      <node concept="3clFbS" id="1UCOV1PpOyQ" role="3clF47">
+        <node concept="3clFbF" id="1UCOV1PD7E1" role="3cqZAp">
+          <node concept="2OqwBi" id="1UCOV1PD7Li" role="3clFbG">
+            <node concept="2WthIp" id="1UCOV1PD7DZ" role="2Oq$k0" />
+            <node concept="2XshWL" id="1UCOV1PD7PI" role="2OqNvi">
+              <ref role="2WH_rO" node="1UCOV1PD6tH" resolve="DesugarDoesNotCauseChanges" />
+              <node concept="3xONca" id="1UCOV1PJ4Ef" role="2XxRq1">
+                <ref role="3xOPvv" node="1UCOV1PJ3RH" resolve="tv1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1UCOV1PDcDn" role="3cqZAp">
+          <node concept="2OqwBi" id="1UCOV1PDcDo" role="3clFbG">
+            <node concept="2WthIp" id="1UCOV1PDcDp" role="2Oq$k0" />
+            <node concept="2XshWL" id="1UCOV1PDcDq" role="2OqNvi">
+              <ref role="2WH_rO" node="1UCOV1PD6tH" resolve="DesugarDoesNotCauseChanges" />
+              <node concept="3xONca" id="1UCOV1PJ6AO" role="2XxRq1">
+                <ref role="3xOPvv" node="1UCOV1PJ5HI" resolve="tv2" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/solutions/Beslistabellen_Test/models/tabellen.mps
+++ b/solutions/Beslistabellen_Test/models/tabellen.mps
@@ -71,6 +71,7 @@
       <concept id="7004474094244907415" name="regelspraak.structure.AbstracteRegelVersie" flags="ngI" index="2KO2Q4">
         <child id="5118870146818423030" name="geldig" index="1nvPAL" />
       </concept>
+      <concept id="6717268411822268012" name="regelspraak.structure.PercentageVanExpressie" flags="ng" index="2QDHpF" />
       <concept id="5696347358893285502" name="regelspraak.structure.ISelectie" flags="ngI" index="137dR0">
         <child id="6774523643279660910" name="selector" index="eaaoM" />
         <child id="9009487889885775372" name="object" index="pQQuc" />
@@ -4751,6 +4752,241 @@
     <node concept="3WogBB" id="4xKWB0uM2k" role="vfxHU">
       <node concept="17AEQp" id="4xKWB0uM2j" role="3WoufU">
         <ref role="17AE6y" node="1kjk$xKv3RH" resolve="ALEF-3177" />
+      </node>
+    </node>
+  </node>
+  <node concept="2bv6Cm" id="70BIiIg6fMY">
+    <property role="TrG5h" value="Issue71" />
+    <node concept="2bvS6$" id="70BIiIg6fMZ" role="2bv6Cn">
+      <property role="TrG5h" value="Person" />
+      <node concept="2bv6ZS" id="70BIiIg6fN0" role="2bv01j">
+        <property role="TrG5h" value="payment" />
+        <property role="16Ztxt" value="true" />
+        <node concept="1EDDeX" id="70BIiIg6fN1" role="1EDDcc">
+          <property role="3GST$d" value="-1" />
+          <node concept="PwxsY" id="70BIiIg6fN2" role="PyN7z">
+            <node concept="Pwxi7" id="70BIiIg6fN3" role="Pwxi2">
+              <property role="Pwxi6" value="1" />
+              <ref role="Pwxi0" to="9nho:2MDo2IIKAjb" resolve="euro" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2bv6ZS" id="70BIiIg6fSN" role="2bv01j">
+        <property role="TrG5h" value="income" />
+        <property role="16Ztxt" value="true" />
+        <node concept="1EDDeX" id="70BIiIg6fSO" role="1EDDcc">
+          <property role="3GST$d" value="2" />
+          <node concept="PwxsY" id="70BIiIg6fSP" role="PyN7z">
+            <node concept="Pwxi7" id="70BIiIg6fSQ" role="Pwxi2">
+              <property role="Pwxi6" value="1" />
+              <ref role="Pwxi0" to="9nho:2MDo2IIKAjb" resolve="euro" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2bv6ZS" id="70BIiIg6fUn" role="2bv01j">
+        <property role="TrG5h" value="age" />
+        <property role="16Ztxt" value="true" />
+        <node concept="1EDDeX" id="70BIiIg6fUo" role="1EDDcc">
+          <property role="3GST$d" value="0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1uxNW$" id="70BIiIg6fN4" role="2bv6Cn" />
+  </node>
+  <node concept="2bQVlO" id="70BIiIg6fZ8">
+    <property role="TrG5h" value="Issue71" />
+    <node concept="i4t92" id="70BIiIg6tWx" role="1HSqhF">
+      <property role="TrG5h" value="Table with percentage of" />
+      <node concept="2X3mv7" id="70BIiIg6tWy" role="kiesI">
+        <node concept="2X3ifB" id="70BIiIg6tWz" role="2X3ifz">
+          <node concept="3_mHL5" id="70BIiIg6tW$" role="2mKM6d">
+            <node concept="c2t0s" id="70BIiIg6tW_" role="eaaoM">
+              <ref role="Qu8KH" node="70BIiIg6fN0" resolve="payment" />
+            </node>
+            <node concept="3_kdyS" id="70BIiIg6tWA" role="pQQuc">
+              <ref role="Qu8KH" node="70BIiIg6fMZ" resolve="Person" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X3ifT" id="70BIiIg6tWB" role="2X3ifS">
+          <property role="2X3IFY" value="5brrC35IcX$/GT" />
+          <node concept="3_mHL5" id="70BIiIg6tWC" role="2oUl7d">
+            <node concept="c2t0s" id="70BIiIg6tWD" role="eaaoM">
+              <ref role="Qu8KH" node="70BIiIg6fUn" resolve="age" />
+            </node>
+            <node concept="3yS1BT" id="70BIiIg6tWE" role="pQQuc">
+              <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X3ifT" id="70BIiIg6tWF" role="2X3ifS">
+          <property role="2X3IFY" value="5brrC35IcXw/LE" />
+          <node concept="3_mHL5" id="70BIiIg6tWG" role="2oUl7d">
+            <node concept="c2t0s" id="70BIiIg6tWH" role="eaaoM">
+              <ref role="Qu8KH" node="70BIiIg6fUn" resolve="age" />
+            </node>
+            <node concept="3yS1BT" id="70BIiIg6tWI" role="pQQuc">
+              <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X3DpY" id="70BIiIg6tWJ" role="2X3ifY">
+          <node concept="2W9DTK" id="70BIiIg6tWK" role="2X3DpX">
+            <ref role="2Wjr0C" node="70BIiIg6tWB" />
+            <node concept="3DFEyr" id="70BIiIg6tWL" role="19Qu69" />
+          </node>
+          <node concept="2W9DTK" id="70BIiIg6tWM" role="2X3DpX">
+            <ref role="2Wjr0C" node="70BIiIg6tWF" />
+            <node concept="1EQTEq" id="70BIiIg6tWN" role="19Qu69">
+              <property role="3e6Tb2" value="18" />
+            </node>
+          </node>
+          <node concept="19B5yA" id="70BIiIg6tWO" role="2X3DpX">
+            <ref role="19B5yx" node="70BIiIg6tWz" />
+            <node concept="2QDHpF" id="70BIiIg6uh4" role="19Qu69">
+              <node concept="3cHhmn" id="70BIiIg6u_E" role="2C$i6h">
+                <property role="3e6Tb2" value="100" />
+              </node>
+              <node concept="3_mHL5" id="70BIiIg6tWP" role="2C$i6l">
+                <node concept="c2t0s" id="70BIiIg6tWQ" role="eaaoM">
+                  <ref role="Qu8KH" node="70BIiIg6fSN" resolve="income" />
+                </node>
+                <node concept="3yS1BT" id="70BIiIg6tWR" role="pQQuc">
+                  <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2X3DpY" id="70BIiIg6tWS" role="2X3ifY">
+          <node concept="2W9DTK" id="70BIiIg6tWT" role="2X3DpX">
+            <ref role="2Wjr0C" node="70BIiIg6tWB" />
+            <node concept="1EQTEq" id="70BIiIg6tWU" role="19Qu69">
+              <property role="3e6Tb2" value="18" />
+            </node>
+          </node>
+          <node concept="2W9DTK" id="70BIiIg6tWV" role="2X3DpX">
+            <ref role="2Wjr0C" node="70BIiIg6tWF" />
+            <node concept="1EQTEq" id="70BIiIg6tWW" role="19Qu69">
+              <property role="3e6Tb2" value="65" />
+            </node>
+          </node>
+          <node concept="19B5yA" id="70BIiIg6tWX" role="2X3DpX">
+            <ref role="19B5yx" node="70BIiIg6tWz" />
+            <node concept="2QDHpF" id="70BIiIg6uJQ" role="19Qu69">
+              <node concept="3cHhmn" id="70BIiIg6uJR" role="2C$i6h">
+                <property role="3e6Tb2" value="50" />
+              </node>
+              <node concept="3_mHL5" id="70BIiIg6uJS" role="2C$i6l">
+                <node concept="c2t0s" id="70BIiIg6uJT" role="eaaoM">
+                  <ref role="Qu8KH" node="70BIiIg6fSN" resolve="income" />
+                </node>
+                <node concept="3yS1BT" id="70BIiIg6uJU" role="pQQuc">
+                  <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2X3DpY" id="70BIiIg6tX1" role="2X3ifY">
+          <node concept="2W9DTK" id="70BIiIg6tX2" role="2X3DpX">
+            <ref role="2Wjr0C" node="70BIiIg6tWB" />
+            <node concept="1EQTEq" id="70BIiIg6tX3" role="19Qu69">
+              <property role="3e6Tb2" value="65" />
+            </node>
+          </node>
+          <node concept="2W9DTK" id="70BIiIg6tX4" role="2X3DpX">
+            <ref role="2Wjr0C" node="70BIiIg6tWF" />
+            <node concept="3DFEyr" id="70BIiIg6tX5" role="19Qu69" />
+          </node>
+          <node concept="19B5yA" id="70BIiIg6tX6" role="2X3DpX">
+            <ref role="19B5yx" node="70BIiIg6tWz" />
+            <node concept="2QDHpF" id="70BIiIg6uMO" role="19Qu69">
+              <node concept="3cHhmn" id="70BIiIg6uMP" role="2C$i6h">
+                <property role="3e6Tb2" value="10" />
+              </node>
+              <node concept="3_mHL5" id="70BIiIg6uMQ" role="2C$i6l">
+                <node concept="c2t0s" id="70BIiIg6uMR" role="eaaoM">
+                  <ref role="Qu8KH" node="70BIiIg6fSN" resolve="income" />
+                </node>
+                <node concept="3yS1BT" id="70BIiIg6uMS" role="pQQuc">
+                  <ref role="3yS1Ki" node="70BIiIg6tWA" resolve="Person" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2ljwA5" id="70BIiIg6tXa" role="1nvPAL" />
+      </node>
+    </node>
+    <node concept="1uxNW$" id="70BIiIg6fZG" role="1HSqhF" />
+  </node>
+  <node concept="1rXTK1" id="1UCOV1Pw$gF">
+    <property role="TrG5h" value="Issue71" />
+    <node concept="210ffa" id="1UCOV1PwESp" role="10_$IM">
+      <property role="TrG5h" value="001" />
+      <node concept="4OhPC" id="1UCOV1PwIcb" role="4Ohaa">
+        <property role="TrG5h" value="P" />
+        <ref role="4OhPH" node="70BIiIg6fMZ" resolve="Person" />
+        <node concept="3_ceKt" id="1UCOV1PwONA" role="4OhPJ">
+          <ref role="3_ceKs" node="70BIiIg6fUn" resolve="age" />
+          <node concept="1EQTEq" id="1UCOV1PwONB" role="3_ceKu">
+            <property role="3e6Tb2" value="35" />
+          </node>
+        </node>
+        <node concept="3_ceKt" id="1UCOV1PwS8s" role="4OhPJ">
+          <ref role="3_ceKs" node="70BIiIg6fSN" resolve="income" />
+          <node concept="1EQTEq" id="1UCOV1PwTMH" role="3_ceKu">
+            <property role="3e6Tb2" value="12" />
+            <node concept="PwxsY" id="1UCOV1PwYR9" role="1jdwn1">
+              <node concept="Pwxi7" id="1UCOV1PwYR8" role="Pwxi2">
+                <property role="Pwxi6" value="1" />
+                <ref role="Pwxi0" to="9nho:2MDo2IIKAjb" resolve="euro" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="4Oh8J" id="1UCOV1PwESq" role="4Ohb1">
+        <ref role="4Oh8G" node="70BIiIg6fMZ" resolve="Person" />
+        <ref role="3teO_M" node="1UCOV1PwIcb" resolve="P" />
+        <node concept="3mzBic" id="1UCOV1PwXam" role="4Ohbj">
+          <property role="V2jGk" value="-1" />
+          <ref role="10Xmnc" node="70BIiIg6fN0" resolve="payment" />
+          <node concept="1EQTEq" id="1UCOV1PwXao" role="3mzBi6">
+            <property role="3e6Tb2" value="6" />
+            <node concept="PwxsY" id="1UCOV1Px2gs" role="1jdwn1">
+              <node concept="Pwxi7" id="1UCOV1Px2gr" role="Pwxi2">
+                <property role="Pwxi6" value="1" />
+                <ref role="Pwxi0" to="9nho:2MDo2IIKAjb" resolve="euro" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2ljwA5" id="1UCOV1Pw$gG" role="3Na4y7">
+      <node concept="2ljiaL" id="1UCOV1Pw$gH" role="2ljwA6">
+        <property role="2ljiaO" value="2026" />
+        <property role="2ljiaN" value="1" />
+        <property role="2ljiaM" value="1" />
+      </node>
+      <node concept="2ljiaL" id="1UCOV1Pw$gI" role="2ljwA7">
+        <property role="2ljiaO" value="2026" />
+        <property role="2ljiaN" value="12" />
+        <property role="2ljiaM" value="31" />
+      </node>
+    </node>
+    <node concept="2ljiaL" id="1UCOV1Pw$gJ" role="1lUMLE">
+      <property role="2ljiaO" value="2026" />
+      <property role="2ljiaN" value="7" />
+      <property role="2ljiaM" value="1" />
+    </node>
+    <node concept="3WogBB" id="1UCOV1PwB$A" role="vfxHU">
+      <node concept="17AEQp" id="1UCOV1PwDew" role="3WoufU">
+        <ref role="17AE6y" node="70BIiIg6fZ8" resolve="Issue71" />
       </node>
     </node>
   </node>

--- a/solutions/test/Regelspraak/models/acties.Verdeling@tests.mps
+++ b/solutions/test/Regelspraak/models/acties.Verdeling@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7bbaf860-5f96-44b4-9731-6e00ae137ece" name="regelspraak" version="30" />
-    <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="18" />
+    <use id="471364db-8078-4933-b2ef-88232bfa34fc" name="gegevensspraak" version="19" />
   </languages>
   <imports>
     <import index="r2nh" ref="r:05a8f765-7ff1-45ab-8d9d-4557ba983db4(regelspraak.typesystem)" />


### PR DESCRIPTION
Using a unit system would sometimes prevented decision tables from showing the equivalent rules in the Inspector. The technical error would start with 'Failed to create cell for node [versie] BeslistabelVersie'.

(ALEFS-1151)